### PR TITLE
Remove roadmap section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,18 +29,6 @@ When configuring, choose:
 
 See [INSTALLATION.md](INSTALLATION.md) for manual installation and troubleshooting.
 
-## Roadmap
-
-### `v1.0.0` Engine & Explorer
-
-1. Local control - basic device functions can be operated using the library
-2. Robust interface - an interface for 3rd party tools (i.e., Home Assistant integration)
-3. Reverse-engineering toolset - ease integration with other device types
-
-### `v2.0.0` Plug & Play for Kospel ecosystem
-
-...
-
 ## Requirements
 
 - Home Assistant 2024.1 or later


### PR DESCRIPTION
Removed roadmap section for future versions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that removes future-looking content; no code or behavioral impact.
> 
> **Overview**
> Removes the *Roadmap* section from `README.md`, deleting the planned `v1.0.0`/`v2.0.0` notes and leaving installation, requirements, and license information unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 637966ea86fef6385157e81ab5edc123e57240d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->