### PR TITLE
Add network discovery for Kospel heaters

### DIFF
--- a/custom_components/kospel/climate.py
+++ b/custom_components/kospel/climate.py
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, get_device_info
+from .const import DOMAIN, get_device_info, get_device_identifier
 from .coordinator import KospelDataUpdateCoordinator
 
 from kospel_cmi.registers.enums import HeaterMode, PumpStatus
@@ -55,8 +55,9 @@ class KospelClimateEntity(
     def __init__(self, coordinator: KospelDataUpdateCoordinator) -> None:
         """Initialize the climate entity."""
         super().__init__(coordinator)
-        self._attr_unique_id = f"{coordinator.entry.entry_id}_climate"
-        self._attr_device_info = get_device_info(coordinator.entry.entry_id)
+        device_id = get_device_identifier(coordinator.entry)
+        self._attr_unique_id = f"{device_id}_climate"
+        self._attr_device_info = get_device_info(coordinator.entry)
 
         self._preset_mode = self._attr_preset_modes[0]
 

--- a/custom_components/kospel/config_flow.py
+++ b/custom_components/kospel/config_flow.py
@@ -1,22 +1,34 @@
 """Config flow for Kospel integration."""
 
+from ipaddress import ip_interface
 from typing import Any
 
+import aiohttp
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.components import network
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
+
+from kospel_cmi import discover_devices, probe_device
 
 from .const import (
     DOMAIN,
     CONF_BACKEND_TYPE,
     CONF_HEATER_IP,
     CONF_DEVICE_ID,
+    CONF_SERIAL_NUMBER,
     CONF_SIMULATION_MODE,
+    DEFAULT_SUBNETS,
     BACKEND_TYPE_HTTP,
     BACKEND_TYPE_YAML,
+    make_unique_id,
 )
+
+
+class CannotConnect(Exception):
+    """Raised when connection to heater fails."""
 
 
 async def validate_http_input(
@@ -24,13 +36,53 @@ async def validate_http_input(
 ) -> dict[str, Any]:
     """Validate HTTP backend input (heater IP and device ID).
 
+    Probes the device via probe_device to verify connectivity and that
+    the device_id exists on the module. Returns title and serial_number on success.
+
     Returns:
-        Dict with "title" for the config entry title.
+        Dict with "title" and optionally "serial_number" for the config entry.
+
+    Raises:
+        CannotConnect: When probe fails or device_id is not found on the module.
     """
-    # Basic validation: IP format and device ID range could be added here
-    heater_ip = data[CONF_HEATER_IP]
+    heater_ip = data[CONF_HEATER_IP].strip()
     device_id = data[CONF_DEVICE_ID]
-    return {"title": f"Kospel Heater {heater_ip} (device {device_id})"}
+
+    async with aiohttp.ClientSession() as session:
+        info = await probe_device(session, heater_ip)
+    if info is None:
+        raise CannotConnect()
+    if device_id not in info.device_ids:
+        raise CannotConnect()
+
+    serial = info.serial_number
+    return {
+        "title": f"Kospel Heater {heater_ip} (device {device_id})",
+        "serial_number": serial,
+    }
+
+
+async def _get_subnets_to_scan(hass: HomeAssistant) -> list[str]:
+    """Get subnets to scan from Network integration or fallback to defaults."""
+    try:
+        adapters = await network.async_get_adapters(hass)
+    except Exception:
+        return DEFAULT_SUBNETS
+
+    subnets: set[str] = set()
+    for adapter in adapters:
+        if not adapter.get("enabled"):
+            continue
+        for ipv4 in adapter.get("ipv4", []):
+            try:
+                iface = ip_interface(
+                    f"{ipv4['address']}/{ipv4['network_prefix']}"
+                )
+                subnets.add(str(iface.network))
+            except (ValueError, KeyError):
+                continue
+
+    return list(subnets) if subnets else DEFAULT_SUBNETS
 
 
 class KospelConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -41,6 +93,7 @@ class KospelConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         """Initialize config flow."""
         self._backend_type: str | None = None
+        self._discovered_devices: list[tuple[Any, int]] = []  # (KospelDeviceInfo, device_id)
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -77,7 +130,42 @@ class KospelConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 },
             )
 
-        # HTTP: show connection details step
+        # HTTP: show connection method choice (Discover vs Manual)
+        return self.async_show_form(
+            step_id="http_method",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("http_method", default="discover"): vol.In(
+                        {
+                            "discover": "option_discover",
+                            "manual": "option_manual",
+                        }
+                    ),
+                }
+            ),
+        )
+
+    async def async_step_http_method(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle HTTP connection method: Discover or Manual."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="http_method",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required("http_method", default="discover"): vol.In(
+                            {
+                                "discover": "option_discover",
+                                "manual": "option_manual",
+                            }
+                        ),
+                    }
+                ),
+            )
+
+        if user_input["http_method"] == "discover":
+            return await self.async_step_discover()
         return self.async_show_form(
             step_id="http",
             data_schema=vol.Schema(
@@ -88,10 +176,126 @@ class KospelConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             ),
         )
 
+    async def _async_run_discovery(self) -> FlowResult:
+        """Run network discovery and return progress_done to transition to result step."""
+        try:
+            subnets = await _get_subnets_to_scan(self.hass)
+            all_devices: list[tuple[Any, int]] = []
+
+            async with aiohttp.ClientSession() as session:
+                for subnet in subnets:
+                    devices = await discover_devices(
+                        session, subnet, timeout=3.0, concurrency_limit=20
+                    )
+                    for info in devices:
+                        for device_id in info.device_ids:
+                            all_devices.append((info, device_id))
+
+            self._discovered_devices = all_devices
+            return self.async_show_progress_done(next_step_id="discover_result")
+        except Exception:
+            self._discovered_devices = []
+            return self.async_show_progress_done(next_step_id="discover_result")
+
+    async def async_step_discover(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Scan network for Kospel devices."""
+        if user_input and user_input.get("action") == "manual":
+            return self.async_show_form(
+                step_id="http",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required(CONF_HEATER_IP): str,
+                        vol.Required(CONF_DEVICE_ID, default=65): int,
+                    }
+                ),
+            )
+
+        progress_task = self.hass.async_create_task(self._async_run_discovery())
+        return self.async_show_progress(
+            step_id="discover",
+            progress_action="discover",
+            progress_task=progress_task,
+        )
+
+    async def async_step_discover_result(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle discovery result: show device list or retry form."""
+        if not self._discovered_devices:
+            return self.async_show_form(
+                step_id="discover",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required("action", default="manual"): vol.In(
+                            {
+                                "retry": "option_retry",
+                                "manual": "option_manual",
+                            }
+                        ),
+                    }
+                ),
+                errors={"base": "no_devices_found"},
+            )
+
+        # Build device selection options
+        options: dict[str, str] = {}
+        for info, device_id in self._discovered_devices:
+            devices = getattr(info, "devices", None) or []
+            model = devices[0].model_name if devices else "?"
+            unique_id = make_unique_id(info.serial_number, device_id)
+            options[unique_id] = (
+                f"{info.host} — {info.serial_number} (dev {device_id}, {model})"
+            )
+
+        return self.async_show_form(
+            step_id="select_device",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("device"): vol.In(options),
+                }
+            ),
+        )
+
+    async def async_step_select_device(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle device selection from discovered list."""
+        if user_input is None:
+            return self.async_abort(reason="unknown")
+
+        selected_unique_id = user_input["device"]
+        info = None
+        device_id = None
+        for dev_info, dev_id in self._discovered_devices:
+            if make_unique_id(dev_info.serial_number, dev_id) == selected_unique_id:
+                info = dev_info
+                device_id = dev_id
+                break
+
+        if info is None or device_id is None:
+            return self.async_abort(reason="unknown")
+
+        await self.async_set_unique_id(selected_unique_id)
+        self._abort_if_unique_id_configured()
+
+        heater_ip = info.host.split(":")[0] if ":" in info.host else info.host
+
+        return self.async_create_entry(
+            title=f"Kospel Heater {heater_ip} (device {device_id})",
+            data={
+                CONF_BACKEND_TYPE: BACKEND_TYPE_HTTP,
+                CONF_HEATER_IP: heater_ip,
+                CONF_DEVICE_ID: device_id,
+                CONF_SERIAL_NUMBER: info.serial_number,
+            },
+        )
+
     async def async_step_http(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Handle HTTP backend connection details."""
+        """Handle HTTP backend connection details (manual entry)."""
         if user_input is None:
             return self.async_show_form(
                 step_id="http",
@@ -119,6 +323,9 @@ class KospelConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_DEVICE_ID: device_id,
                     },
                 )
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+                info = {}
             except Exception:
                 errors["base"] = "unknown"
                 info = {}
@@ -135,13 +342,23 @@ class KospelConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 errors=errors,
             )
 
+        serial = info.get("serial_number")
+        unique_id = make_unique_id(serial, device_id) if serial else None
+        if unique_id:
+            await self.async_set_unique_id(unique_id)
+            self._abort_if_unique_id_configured()
+
+        entry_data: dict[str, Any] = {
+            CONF_BACKEND_TYPE: BACKEND_TYPE_HTTP,
+            CONF_HEATER_IP: heater_ip,
+            CONF_DEVICE_ID: device_id,
+        }
+        if serial is not None:
+            entry_data[CONF_SERIAL_NUMBER] = serial
+
         return self.async_create_entry(
             title=info.get("title", f"Kospel Heater {heater_ip}"),
-            data={
-                CONF_BACKEND_TYPE: BACKEND_TYPE_HTTP,
-                CONF_HEATER_IP: heater_ip,
-                CONF_DEVICE_ID: device_id,
-            },
+            data=entry_data,
         )
 
     async def async_migrate_entry(

--- a/custom_components/kospel/const.py
+++ b/custom_components/kospel/const.py
@@ -2,9 +2,12 @@
 
 from datetime import timedelta
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from homeassistant.helpers.entity import DeviceInfo
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
 
 DOMAIN = "kospel"
 
@@ -12,7 +15,16 @@ DOMAIN = "kospel"
 CONF_BACKEND_TYPE = "backend_type"
 CONF_HEATER_IP = "heater_ip"
 CONF_DEVICE_ID = "device_id"
+CONF_SERIAL_NUMBER = "serial_number"
 CONF_SIMULATION_MODE = "simulation_mode"  # Deprecated; used for migration only
+
+# Default subnets for discovery when Network integration returns none
+DEFAULT_SUBNETS = [
+    "192.168.1.0/24",
+    "192.168.0.0/24",
+    "192.168.101.0/24",
+    "10.0.0.0/24",
+]
 
 # Backend type values
 BACKEND_TYPE_HTTP = "http"
@@ -45,14 +57,43 @@ def get_yaml_state_file_path(integration_dir: Optional[Path] = None) -> Path:
     return integration_dir / "data" / "state.yaml"
 
 
-def get_device_info(entry_id: str) -> DeviceInfo:
+def make_unique_id(serial_number: str, device_id: int) -> str:
+    """Build unique_id for device registry (enables discovery update on IP change).
+
+    Args:
+        serial_number: Device serial number from probe/discovery.
+        device_id: Device ID (1-255).
+
+    Returns:
+        Unique identifier string, e.g. "mi01_00006047_65".
+    """
+    return f"{serial_number}_{device_id}"
+
+
+def get_device_identifier(entry: "ConfigEntry") -> str:
+    """Return identifier for entities (unique_id prefix). Uses serial_deviceid or entry_id."""
+    serial = entry.data.get(CONF_SERIAL_NUMBER)
+    device_id = entry.data.get(CONF_DEVICE_ID)
+    if serial is not None and device_id is not None:
+        return make_unique_id(serial, device_id)
+    return entry.entry_id
+
+
+def get_device_info(entry: "ConfigEntry") -> DeviceInfo:
     """Return DeviceInfo for the heater device.
 
-    Used by all entities to attach to the same device in the device registry.
-    Device name is translatable via strings.json under device.heater.name.
+    Uses unique_id (serial_deviceid) when available for discovery updates on IP change.
+    Falls back to entry_id for legacy entries without serial_number.
+
+    Args:
+        entry: Config entry for the heater.
+
+    Returns:
+        DeviceInfo for the device registry.
     """
+    identifier = get_device_identifier(entry)
     return DeviceInfo(
-        identifiers={(DOMAIN, entry_id)},
+        identifiers={(DOMAIN, identifier)},
         name="Kospel Heater",
         manufacturer="Kospel",
         model="Electric Heater",

--- a/custom_components/kospel/manifest.json
+++ b/custom_components/kospel/manifest.json
@@ -5,10 +5,10 @@
   "config_flow": true,
   "documentation": "https://github.com/JanKrl/ha-kospel-cmi",
   "issue_tracker": "https://github.com/JanKrl/ha-kospel-cmi/issues",
-  "dependencies": ["http"],
+  "dependencies": ["http", "network"],
   "requirements": [
     "aiohttp>=3.13.3",
-    "kospel-cmi-lib==0.1.0a4"
+    "kospel-cmi-lib==0.1.0a6"
   ],
   "codeowners": ["@JanKrl"],
   "integration_type": "hub",

--- a/custom_components/kospel/sensor.py
+++ b/custom_components/kospel/sensor.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, get_device_info
+from .const import DOMAIN, get_device_info, get_device_identifier
 from .coordinator import KospelDataUpdateCoordinator
 
 from kospel_cmi.controller.api import HeaterController
@@ -41,25 +41,25 @@ async def async_setup_entry(
     for unique_id_suffix, setting_name in temperature_sensors:
         entities.append(
             KospelTemperatureSensor(
-                coordinator, entry.entry_id, unique_id_suffix, setting_name
+                coordinator, entry, unique_id_suffix, setting_name
             )
         )
 
     # Pressure sensor
-    entities.append(KospelPressureSensor(coordinator, entry.entry_id))
+    entities.append(KospelPressureSensor(coordinator, entry))
 
     # Status sensors: (unique_id_suffix, translation_key, setting_name)
     entities.append(
         KospelPumpStatusSensor(
-            coordinator, entry.entry_id, "pump_co", "is_pump_co_running"
+            coordinator, entry, "pump_co", "is_pump_co_running"
         )
     )
     entities.append(
         KospelPumpStatusSensor(
-            coordinator, entry.entry_id, "pump_circulation", "is_pump_circulation_running"
+            coordinator, entry, "pump_circulation", "is_pump_circulation_running"
         )
     )
-    entities.append(KospelValvePositionSensor(coordinator, entry.entry_id))
+    entities.append(KospelValvePositionSensor(coordinator, entry))
 
     async_add_entities(entities)
 
@@ -72,15 +72,16 @@ class KospelSensorEntity(CoordinatorEntity[KospelDataUpdateCoordinator], SensorE
     def __init__(
         self,
         coordinator: KospelDataUpdateCoordinator,
-        entry_id: str,
+        entry: ConfigEntry,
         unique_id_suffix: str,
         translation_key: str,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
-        self._attr_unique_id = f"{entry_id}_{unique_id_suffix}"
+        device_id = get_device_identifier(entry)
+        self._attr_unique_id = f"{device_id}_{unique_id_suffix}"
         self._attr_translation_key = translation_key
-        self._attr_device_info = get_device_info(entry_id)
+        self._attr_device_info = get_device_info(entry)
 
     @property
     def available(self) -> bool:
@@ -98,12 +99,12 @@ class KospelTemperatureSensor(KospelSensorEntity):
     def __init__(
         self,
         coordinator: KospelDataUpdateCoordinator,
-        entry_id: str,
+        entry: ConfigEntry,
         unique_id_suffix: str,
         setting_name: str,
     ) -> None:
         """Initialize the temperature sensor."""
-        super().__init__(coordinator, entry_id, unique_id_suffix, unique_id_suffix)
+        super().__init__(coordinator, entry, unique_id_suffix, unique_id_suffix)
         self._setting_name = setting_name
 
     @property
@@ -127,10 +128,10 @@ class KospelPressureSensor(KospelSensorEntity):
     def __init__(
         self,
         coordinator: KospelDataUpdateCoordinator,
-        entry_id: str,
+        entry: ConfigEntry,
     ) -> None:
         """Initialize the pressure sensor."""
-        super().__init__(coordinator, entry_id, "pressure", "pressure")
+        super().__init__(coordinator, entry, "pressure", "pressure")
 
     @property
     def native_value(self) -> float | None:
@@ -149,12 +150,12 @@ class KospelPumpStatusSensor(KospelSensorEntity):
     def __init__(
         self,
         coordinator: KospelDataUpdateCoordinator,
-        entry_id: str,
+        entry: ConfigEntry,
         unique_id_suffix: str,
         setting_name: str,
     ) -> None:
         """Initialize the pump status sensor."""
-        super().__init__(coordinator, entry_id, unique_id_suffix, unique_id_suffix)
+        super().__init__(coordinator, entry, unique_id_suffix, unique_id_suffix)
         self._setting_name = setting_name
 
     @property
@@ -179,10 +180,10 @@ class KospelValvePositionSensor(KospelSensorEntity):
     def __init__(
         self,
         coordinator: KospelDataUpdateCoordinator,
-        entry_id: str,
+        entry: ConfigEntry,
     ) -> None:
         """Initialize the valve position sensor."""
-        super().__init__(coordinator, entry_id, "valve_position", "valve_position")
+        super().__init__(coordinator, entry, "valve_position", "valve_position")
 
     @property
     def native_value(self) -> str | None:

--- a/custom_components/kospel/strings.json
+++ b/custom_components/kospel/strings.json
@@ -17,6 +17,35 @@
           "option_yaml": "File-based (development)"
         }
       },
+      "http_method": {
+        "title": "Connection method",
+        "description": "Discover devices on your network or enter connection details manually.",
+        "data": {
+          "http_method": "Method"
+        },
+        "options": {
+          "option_discover": "Discover devices",
+          "option_manual": "Enter manually"
+        }
+      },
+      "discover": {
+        "title": "Scanning network",
+        "description": "Scanning for Kospel devices. This may take a minute.",
+        "data": {
+          "action": "Action"
+        },
+        "options": {
+          "option_retry": "Retry scan",
+          "option_manual": "Enter manually"
+        }
+      },
+      "select_device": {
+        "title": "Select device",
+        "description": "Choose the Kospel device to add.",
+        "data": {
+          "device": "Device"
+        }
+      },
       "http": {
         "title": "Heater connection",
         "description": "Enter the heater IP address and device ID. URL will be http://[IP]/api/dev/[ID].",
@@ -26,10 +55,17 @@
         }
       }
     },
+    "progress": {
+      "discover": {
+        "title": "Scanning network",
+        "description": "Searching for Kospel devices on your network. This may take a minute."
+      }
+    },
     "error": {
       "cannot_connect": "Failed to connect to heater",
       "invalid_auth": "Invalid authentication",
       "invalid_device_id": "Device ID must be between 1 and 255",
+      "no_devices_found": "No Kospel devices found on the network",
       "unknown": "Unexpected error occurred"
     },
     "abort": {

--- a/custom_components/kospel/switch.py
+++ b/custom_components/kospel/switch.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, get_device_info
+from .const import DOMAIN, get_device_info, get_device_identifier
 from .coordinator import KospelDataUpdateCoordinator
 
 from kospel_cmi.registers.enums import ManualMode, WaterHeaterEnabled
@@ -24,8 +24,8 @@ async def async_setup_entry(
     coordinator: KospelDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
     entities = [
-        KospelManualModeSwitch(coordinator, entry.entry_id),
-        KospelWaterHeaterSwitch(coordinator, entry.entry_id),
+        KospelManualModeSwitch(coordinator, entry),
+        KospelWaterHeaterSwitch(coordinator, entry),
     ]
 
     async_add_entities(entities)
@@ -39,15 +39,16 @@ class KospelSwitchEntity(CoordinatorEntity[KospelDataUpdateCoordinator], SwitchE
     def __init__(
         self,
         coordinator: KospelDataUpdateCoordinator,
-        entry_id: str,
+        entry: ConfigEntry,
         unique_id_suffix: str,
         translation_key: str,
     ) -> None:
         """Initialize the switch."""
         super().__init__(coordinator)
-        self._attr_unique_id = f"{entry_id}_{unique_id_suffix}"
+        device_id = get_device_identifier(entry)
+        self._attr_unique_id = f"{device_id}_{unique_id_suffix}"
         self._attr_translation_key = translation_key
-        self._attr_device_info = get_device_info(entry_id)
+        self._attr_device_info = get_device_info(entry)
 
     @property
     def available(self) -> bool:
@@ -61,10 +62,10 @@ class KospelManualModeSwitch(KospelSwitchEntity):
     def __init__(
         self,
         coordinator: KospelDataUpdateCoordinator,
-        entry_id: str,
+        entry: ConfigEntry,
     ) -> None:
         """Initialize the manual mode switch."""
-        super().__init__(coordinator, entry_id, "manual_mode", "manual_mode")
+        super().__init__(coordinator, entry, "manual_mode", "manual_mode")
 
     @property
     def is_on(self) -> bool:
@@ -103,10 +104,10 @@ class KospelWaterHeaterSwitch(KospelSwitchEntity):
     def __init__(
         self,
         coordinator: KospelDataUpdateCoordinator,
-        entry_id: str,
+        entry: ConfigEntry,
     ) -> None:
         """Initialize the water heater switch."""
-        super().__init__(coordinator, entry_id, "water_heater", "water_heater")
+        super().__init__(coordinator, entry, "water_heater", "water_heater")
 
     @property
     def is_on(self) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license-files = ["LICENSE*"]
 requires-python = ">=3.11"
 dependencies = [
     "aiohttp>=3.13.3",
-    "kospel-cmi-lib==0.1.0a4",
+    "kospel-cmi-lib==0.1.0a6",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -37,6 +37,7 @@ dev = [
     "pytest-cov>=5.0.0",
     "pytest-mock>=3.14.0",
     "aioresponses>=0.7.6",
+    "voluptuous>=0.13.0",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,236 @@
+"""Tests for config flow and related helpers.
+
+Uses sys.modules mocking to avoid requiring homeassistant at test runtime,
+since homeassistant has strict dependency constraints that conflict with
+the project's aiohttp version.
+"""
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Mock homeassistant before importing integration modules.
+# homeassistant must be a module (have __path__) for "from homeassistant.x import y" to work.
+class _HAModule:
+    __path__ = []
+    __file__ = ""
+    __name__ = "homeassistant"
+
+
+_ha = _HAModule()
+sys.modules["homeassistant"] = _ha
+sys.modules["homeassistant.config_entries"] = MagicMock()
+sys.modules["homeassistant.components"] = MagicMock()
+sys.modules["homeassistant.components.network"] = MagicMock()
+sys.modules["homeassistant.components.climate"] = MagicMock()
+sys.modules["homeassistant.components.sensor"] = MagicMock()
+sys.modules["homeassistant.components.switch"] = MagicMock()
+sys.modules["homeassistant.const"] = MagicMock()
+sys.modules["homeassistant.core"] = MagicMock()
+sys.modules["homeassistant.data_entry_flow"] = MagicMock()
+sys.modules["homeassistant.exceptions"] = MagicMock()
+sys.modules["homeassistant.helpers"] = MagicMock()
+sys.modules["homeassistant.helpers.entity"] = MagicMock()
+sys.modules["homeassistant.helpers.entity_platform"] = MagicMock()
+sys.modules["homeassistant.helpers.update_coordinator"] = MagicMock()
+
+# DeviceInfo is typically a TypedDict - use a simple dict-like
+def _device_info(**kwargs):
+    return kwargs
+
+
+sys.modules["homeassistant.helpers.entity"].DeviceInfo = _device_info
+
+from custom_components.kospel.const import (
+    CONF_DEVICE_ID,
+    CONF_SERIAL_NUMBER,
+    DEFAULT_SUBNETS,
+    make_unique_id,
+    get_device_identifier,
+    get_device_info,
+)
+from custom_components.kospel.config_flow import (
+    CannotConnect,
+    validate_http_input,
+    _get_subnets_to_scan,
+)
+
+
+class TestMakeUniqueId:
+    """Tests for make_unique_id."""
+
+    def test_returns_serial_and_device_id(self) -> None:
+        """make_unique_id combines serial_number and device_id."""
+        assert make_unique_id("mi01_00006047", 65) == "mi01_00006047_65"
+
+    def test_handles_different_device_ids(self) -> None:
+        """make_unique_id works for various device IDs."""
+        assert make_unique_id("sn123", 1) == "sn123_1"
+        assert make_unique_id("sn123", 255) == "sn123_255"
+
+
+class TestGetDeviceIdentifier:
+    """Tests for get_device_identifier."""
+
+    def test_uses_serial_and_device_id_when_available(self) -> None:
+        """get_device_identifier uses make_unique_id when serial in entry."""
+        entry = MagicMock()
+        entry.data = {CONF_SERIAL_NUMBER: "mi01_001", CONF_DEVICE_ID: 65}
+        entry.entry_id = "abc-123"
+        assert get_device_identifier(entry) == "mi01_001_65"
+
+    def test_fallback_to_entry_id_when_no_serial(self) -> None:
+        """get_device_identifier falls back to entry_id for legacy entries."""
+        entry = MagicMock()
+        entry.data = {CONF_DEVICE_ID: 65}
+        entry.entry_id = "legacy-uuid"
+        assert get_device_identifier(entry) == "legacy-uuid"
+
+    def test_fallback_when_device_id_missing(self) -> None:
+        """get_device_identifier falls back when device_id missing."""
+        entry = MagicMock()
+        entry.data = {CONF_SERIAL_NUMBER: "sn"}
+        entry.entry_id = "uuid"
+        assert get_device_identifier(entry) == "uuid"
+
+
+class TestGetDeviceInfo:
+    """Tests for get_device_info."""
+
+    def test_identifiers_use_unique_id_when_serial_present(self) -> None:
+        """DeviceInfo.identifiers uses make_unique_id when serial available."""
+        entry = MagicMock()
+        entry.data = {CONF_SERIAL_NUMBER: "mi01_001", CONF_DEVICE_ID: 65}
+        entry.entry_id = "abc"
+        info = get_device_info(entry)
+        assert ("kospel", "mi01_001_65") in info["identifiers"]
+
+    def test_identifiers_use_entry_id_for_legacy(self) -> None:
+        """DeviceInfo.identifiers uses entry_id for legacy entries."""
+        entry = MagicMock()
+        entry.data = {}
+        entry.entry_id = "legacy-uuid"
+        info = get_device_info(entry)
+        assert ("kospel", "legacy-uuid") in info["identifiers"]
+
+
+class TestValidateHttpInput:
+    """Tests for validate_http_input."""
+
+    @pytest.mark.asyncio
+    async def test_returns_title_and_serial_on_success(self) -> None:
+        """validate_http_input returns title and serial_number when probe succeeds."""
+        mock_info = MagicMock()
+        mock_info.device_ids = [65]
+        mock_info.serial_number = "mi01_00006047"
+
+        with patch(
+            "custom_components.kospel.config_flow.probe_device",
+            new_callable=AsyncMock,
+            return_value=mock_info,
+        ):
+            result = await validate_http_input(
+                MagicMock(),
+                {"heater_ip": "192.168.1.100", "device_id": 65},
+            )
+        assert result["title"] == "Kospel Heater 192.168.1.100 (device 65)"
+        assert result["serial_number"] == "mi01_00006047"
+
+    @pytest.mark.asyncio
+    async def test_raises_cannot_connect_when_probe_returns_none(self) -> None:
+        """validate_http_input raises CannotConnect when probe returns None."""
+        with patch(
+            "custom_components.kospel.config_flow.probe_device",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            with pytest.raises(CannotConnect):
+                await validate_http_input(
+                    MagicMock(),
+                    {"heater_ip": "192.168.1.100", "device_id": 65},
+                )
+
+    @pytest.mark.asyncio
+    async def test_raises_cannot_connect_when_device_id_not_in_module(
+        self,
+    ) -> None:
+        """validate_http_input raises CannotConnect when device_id not in device_ids."""
+        mock_info = MagicMock()
+        mock_info.device_ids = [66, 67]
+        mock_info.serial_number = "mi01_001"
+
+        with patch(
+            "custom_components.kospel.config_flow.probe_device",
+            new_callable=AsyncMock,
+            return_value=mock_info,
+        ):
+            with pytest.raises(CannotConnect):
+                await validate_http_input(
+                    MagicMock(),
+                    {"heater_ip": "192.168.1.100", "device_id": 65},
+                )
+
+
+class TestGetSubnetsToScan:
+    """Tests for _get_subnets_to_scan."""
+
+    @pytest.mark.asyncio
+    async def test_returns_default_subnets_when_network_fails(self) -> None:
+        """_get_subnets_to_scan returns DEFAULT_SUBNETS when network raises."""
+        hass = MagicMock()
+        with patch(
+            "custom_components.kospel.config_flow.network.async_get_adapters",
+            new_callable=AsyncMock,
+            side_effect=Exception("Network not loaded"),
+        ):
+            result = await _get_subnets_to_scan(hass)
+        assert result == DEFAULT_SUBNETS
+
+    @pytest.mark.asyncio
+    async def test_returns_subnets_from_adapters(self) -> None:
+        """_get_subnets_to_scan builds subnets from Network adapters."""
+        hass = MagicMock()
+        adapters = [
+            {
+                "enabled": True,
+                "ipv4": [
+                    {"address": "192.168.1.100", "network_prefix": 24},
+                ],
+            },
+        ]
+        with patch(
+            "custom_components.kospel.config_flow.network.async_get_adapters",
+            new_callable=AsyncMock,
+            return_value=adapters,
+        ):
+            result = await _get_subnets_to_scan(hass)
+        assert "192.168.1.0/24" in result
+
+    @pytest.mark.asyncio
+    async def test_skips_disabled_adapters(self) -> None:
+        """_get_subnets_to_scan skips disabled adapters."""
+        hass = MagicMock()
+        adapters = [
+            {"enabled": False, "ipv4": [{"address": "10.0.0.1", "network_prefix": 24}]},
+        ]
+        with patch(
+            "custom_components.kospel.config_flow.network.async_get_adapters",
+            new_callable=AsyncMock,
+            return_value=adapters,
+        ):
+            result = await _get_subnets_to_scan(hass)
+        assert result == DEFAULT_SUBNETS
+
+    @pytest.mark.asyncio
+    async def test_returns_default_when_no_ipv4(self) -> None:
+        """_get_subnets_to_scan returns DEFAULT_SUBNETS when no IPv4 addresses."""
+        hass = MagicMock()
+        adapters = [{"enabled": True, "ipv4": []}]
+        with patch(
+            "custom_components.kospel.config_flow.network.async_get_adapters",
+            new_callable=AsyncMock,
+            return_value=adapters,
+        ):
+            result = await _get_subnets_to_scan(hass)
+        assert result == DEFAULT_SUBNETS

--- a/uv.lock
+++ b/uv.lock
@@ -391,12 +391,13 @@ dev = [
     { name = "pytest-mock" },
     { name = "python-dotenv" },
     { name = "ruff" },
+    { name = "voluptuous" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.3" },
-    { name = "kospel-cmi-lib", specifier = "==0.1.0a4" },
+    { name = "kospel-cmi-lib", specifier = "==0.1.0a6" },
 ]
 
 [package.metadata.requires-dev]
@@ -409,6 +410,7 @@ dev = [
     { name = "pytest-mock", specifier = ">=3.14.0" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "ruff", specifier = ">=0.14.10" },
+    { name = "voluptuous", specifier = ">=0.13.0" },
 ]
 
 [[package]]
@@ -431,7 +433,7 @@ wheels = [
 
 [[package]]
 name = "kospel-cmi-lib"
-version = "0.1.0a4"
+version = "0.1.0a6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -439,9 +441,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/cc/137f168102e8e4e369c1e1be4b46bf15251fca5f740af78c271509c5c267/kospel_cmi_lib-0.1.0a4.tar.gz", hash = "sha256:20d1693344c1539a1e403edfa3c6cabfe400878a9ceb03146f21e328cab0ae8e", size = 22832, upload-time = "2026-02-15T13:22:49.663Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/3d/107e149eaebb7893612f0075311fad04f9db0b590613d36d60212b98746c/kospel_cmi_lib-0.1.0a6.tar.gz", hash = "sha256:652e626368f974ca962ab14c3a58f18a9aa80c5de67d1b75aa1742a78bc552de", size = 33618, upload-time = "2026-03-07T16:23:01.543Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/c3/edf29d1ae569a4d2b90306caf7d8dd8efc0f52189cf9653408bc47bb7811/kospel_cmi_lib-0.1.0a4-py3-none-any.whl", hash = "sha256:9f5911fdd6deb01c245fc0fc1bd441d446ce94ea6cb1ca24e7e3cb2b07bf3d1d", size = 30738, upload-time = "2026-02-15T13:22:48.384Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/05/903e5f308030dff22956baa0b2f4b90e9cae3c18c455a1a56b5ad534f539/kospel_cmi_lib-0.1.0a6-py3-none-any.whl", hash = "sha256:8cd7e6a7c9697b6ee3a0e0e1ed9b7e5f7f72b1e6621214709c3bbe13975314a9", size = 46042, upload-time = "2026-03-07T16:23:00.093Z" },
 ]
 
 [[package]]
@@ -1029,6 +1031,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "voluptuous"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/f4/0738e6849858deae22218be3bbb8207ba83a96e9d0ec7e8e8cd67b30e5ca/voluptuous-0.16.0.tar.gz", hash = "sha256:006535e22fed944aec17bef6e8725472476194743c87bd233e912eb463f8ff05", size = 54238, upload-time = "2025-12-18T23:18:46.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/00/0e0da784245c93cf346150ab67634177bf277f93b7a162bb56c928c39c04/voluptuous-0.16.0-py3-none-any.whl", hash = "sha256:ee342095263e1b5afbd4d418cb5adc92810eebfd07696bb033a261210df33db4", size = 31931, upload-time = "2025-12-18T23:18:44.694Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Add network discovery for Kospel heaters

## Summary

Adds network discovery for Kospel heaters so users can find and add devices without manually entering IP and device ID. Also introduces serial-based device identification for stable entity IDs when the heater's IP changes.

## Changes

### Network discovery
- **Discover vs manual**: After selecting HTTP, users can either discover devices on the network or enter connection details manually.
- **Network integration**: Uses Home Assistant's Network integration to obtain subnets to scan, with fallback to common subnets (`192.168.1.0/24`, `192.168.0.0/24`, etc.).
- **Progress UX**: Uses `async_show_progress` with a background task so the UI shows a progress screen during discovery instead of appearing frozen.
- **Device selection**: Discovered devices are listed with host, serial number, device ID, and model; users select which device to add.

### Serial-based device identification
- **`make_unique_id(serial_number, device_id)`**: Builds stable unique IDs for the device registry.
- **`get_device_identifier(entry)`**: Returns the identifier for entities, using serial+device_id when available, falling back to `entry_id` for legacy entries.
- **Entity updates**: Climate, sensor, and switch entities now use the new identifier so devices remain correctly linked when the heater's IP changes.

### Validation
- **Probe before configure**: Manual entry validates connectivity and device ID via `probe_device` before creating the config entry.
- **`CannotConnect`**: Raised when probe fails or device ID is invalid.

### Dependencies
- **Network integration**: Added as a dependency for subnet discovery.
- **kospel-cmi-lib**: Bumped to `0.1.0a6` (pinned) for `discover_devices` and `probe_device`.

## Technical details
- Discovery uses `async_show_progress` with `progress_task` (HA 2024.8+).
- New flow steps: `http_method`, `discover`, `discover_result`, `select_device`.
- Defensive handling for `info.devices` to avoid `AttributeError`/`IndexError`.

## Testing
- New `tests/test_config_flow.py` covering `make_unique_id`, `get_device_identifier`, `get_device_info`, `validate_http_input`, and `_get_subnets_to_scan`.
- All 35 tests pass.

## Breaking changes
None. Existing entries without `serial_number` continue to use `entry_id` as the device identifier.
