### PR TITLE
Improve entity naming and add Polish translations

### DIFF
--- a/custom_components/kospel/strings.json
+++ b/custom_components/kospel/strings.json
@@ -74,13 +74,13 @@
   },
   "entity": {
     "sensor": {
-      "room_temperature_economy": { "name": "Room Temperature Economy" },
-      "room_temperature_comfort": { "name": "Room Temperature Comfort" },
-      "room_temperature_comfort_plus": { "name": "Room Temperature Comfort Plus" },
-      "room_temperature_comfort_minus": { "name": "Room Temperature Comfort Minus" },
-      "cwu_temperature_economy": { "name": "CWU Temperature Economy" },
-      "cwu_temperature_comfort": { "name": "CWU Temperature Comfort" },
-      "manual_temperature": { "name": "Manual Temperature" },
+      "room_temperature_economy": { "name": "Room Temp. Economy" },
+      "room_temperature_comfort": { "name": "Room Temp. Comfort" },
+      "room_temperature_comfort_plus": { "name": "Room Temp. Comfort Plus" },
+      "room_temperature_comfort_minus": { "name": "Room Temp. Comfort Minus" },
+      "cwu_temperature_economy": { "name": "DHW Temp. Economy" },
+      "cwu_temperature_comfort": { "name": "DHW Temp. Comfort" },
+      "manual_temperature": { "name": "Target Temperature" },
       "pressure": { "name": "Pressure" },
       "pump_co": {
         "name": "Pump CO",

--- a/custom_components/kospel/translations/pl.json
+++ b/custom_components/kospel/translations/pl.json
@@ -1,0 +1,58 @@
+{
+  "device": {
+    "heater": {
+      "name": "Grzejnik Kospel"
+    }
+  },
+  "entity": {
+    "sensor": {
+      "room_temperature_economy": { "name": "Temp. pokoju ekonomiczna" },
+      "room_temperature_comfort": { "name": "Temp. pokoju komfort" },
+      "room_temperature_comfort_plus": { "name": "Temp. pokoju komfort plus" },
+      "room_temperature_comfort_minus": { "name": "Temp. pokoju komfort minus" },
+      "cwu_temperature_economy": { "name": "Temp. CWU ekonomiczna" },
+      "cwu_temperature_comfort": { "name": "Temp. CWU komfort" },
+      "manual_temperature": { "name": "Temp. docelowa" },
+      "pressure": { "name": "Ciśnienie" },
+      "pump_co": {
+        "name": "Pompa CO",
+        "state": {
+          "Running": "Praca",
+          "Idle": "Bezczynność"
+        }
+      },
+      "pump_circulation": {
+        "name": "Pompa obiegowa",
+        "state": {
+          "Running": "Praca",
+          "Idle": "Bezczynność"
+        }
+      },
+      "valve_position": {
+        "name": "Pozycja zaworu",
+        "state": {
+          "DHW": "CWU",
+          "CO": "CO"
+        }
+      }
+    },
+    "switch": {
+      "manual_mode": { "name": "Tryb ręczny" },
+      "water_heater": { "name": "Podgrzewacz wody" }
+    },
+    "climate": {
+      "heater": {
+        "name": "Grzejnik",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "Summer": "Lato",
+              "Winter": "Zima",
+              "Off": "Wyłączony"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem
Entity names were generic and hard to distinguish:

- Multiple entities labeled "Kospel" (climate, switches, status sensors)
- Temperature sensors all showing "Temperatura" in Polish UI
- Status sensors (pump, valve) not clearly identified

## Solution
1. Polish translations (translations/pl.json)

- Added Polish translations for all entity names
- Device name: "Grzejnik Kospel"
- Sensors: descriptive names (e.g. "Temp. pokoju ekonomiczna", "Pompa CO", "Ciśnienie")
- Switches: "Tryb ręczny", "Podgrzewacz wody"
- Climate: "Grzejnik"
- State translations: Running → Praca, Idle → Bezczynność, Summer → Lato, Winter → Zima

2. English entity names (strings.json)

- Shortened temperature labels: "Room Temp." instead of "Room Temperature"
- Renamed "CWU Temperature" to "DHW Temp." (Domestic Hot Water)
- Renamed "Manual Temperature" to "Target Temperature"
- Alignment with Home Assistant guidelines
- Uses has_entity_name = True and translation_key for entity names
- Entity names follow the Device + Entity pattern
- Translations follow the entity.{domain}.{translation_key}.name structure

## Testing
- All 35 tests pass
-No changes to integration logic, only translations and strings