### PR TITLE
Add water_heater platform and extend climate presets (Party, Vacation)

### DIFF
--- a/custom_components/kospel/__init__.py
+++ b/custom_components/kospel/__init__.py
@@ -26,7 +26,7 @@ from kospel_cmi.kospel.backend import HttpRegisterBackend, YamlRegisterBackend
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[str] = ["climate", "sensor", "switch"]
+PLATFORMS: list[str] = ["climate", "sensor", "switch", "water_heater"]
 
 
 async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:

--- a/custom_components/kospel/climate.py
+++ b/custom_components/kospel/climate.py
@@ -18,7 +18,12 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN, get_device_info, get_device_identifier
 from .coordinator import KospelDataUpdateCoordinator
 
-from kospel_cmi.registers.enums import HeaterMode, PumpStatus
+from kospel_cmi.registers.enums import (
+    HeaterMode,
+    PartyMode,
+    PumpStatus,
+    VacationMode,
+)
 from kospel_cmi.controller.api import HeaterController
 
 _LOGGER = logging.getLogger(__name__)
@@ -50,7 +55,9 @@ class KospelClimateEntity(
         | ClimateEntityFeature.TURN_ON
         | ClimateEntityFeature.TURN_OFF
     )
-    _attr_preset_modes = [mode.value for mode in HeaterMode]
+    _attr_preset_modes = (
+        [mode.value for mode in HeaterMode] + ["Party", "Vacation"]
+    )
 
     def __init__(self, coordinator: KospelDataUpdateCoordinator) -> None:
         """Initialize the climate entity."""
@@ -98,7 +105,12 @@ class KospelClimateEntity(
 
     @property
     def preset_mode(self) -> str | None:
-        """Current preset mode is the heater mode."""
+        """Current preset mode: Vacation > Party > heater_mode."""
+        controller: HeaterController = self.coordinator.data
+        if getattr(controller, "is_vacation_mode_enabled", None) == VacationMode.ENABLED:
+            return "Vacation"
+        if getattr(controller, "is_party_mode_enabled", None) == PartyMode.ENABLED:
+            return "Party"
         return self._heater_mode.value
 
     @property
@@ -132,7 +144,17 @@ class KospelClimateEntity(
         """Set new preset mode."""
         _LOGGER.debug("Setting preset mode to %s", preset_mode)
         controller: HeaterController = self.coordinator.data
-        controller.heater_mode = HeaterMode(preset_mode)
+
+        if preset_mode == "Vacation":
+            controller.is_vacation_mode_enabled = VacationMode.ENABLED
+            controller.is_party_mode_enabled = PartyMode.DISABLED
+        elif preset_mode == "Party":
+            controller.is_party_mode_enabled = PartyMode.ENABLED
+            controller.is_vacation_mode_enabled = VacationMode.DISABLED
+        else:
+            controller.heater_mode = HeaterMode(preset_mode)
+            controller.is_party_mode_enabled = PartyMode.DISABLED
+            controller.is_vacation_mode_enabled = VacationMode.DISABLED
 
         await controller.save()
         self.async_write_ha_state()

--- a/custom_components/kospel/manifest.json
+++ b/custom_components/kospel/manifest.json
@@ -8,7 +8,7 @@
   "dependencies": ["http", "network"],
   "requirements": [
     "aiohttp>=3.13.3",
-    "kospel-cmi-lib==0.1.0a6"
+    "kospel-cmi-lib==0.1.0a7"
   ],
   "codeowners": ["@JanKrl"],
   "integration_type": "hub",

--- a/custom_components/kospel/strings.json
+++ b/custom_components/kospel/strings.json
@@ -105,8 +105,10 @@
       }
     },
     "switch": {
-      "manual_mode": { "name": "Manual Mode" },
-      "water_heater": { "name": "Water Heater" }
+      "manual_mode": { "name": "Manual Mode" }
+    },
+    "water_heater": {
+      "dhw": { "name": "Domestic Hot Water" }
     },
     "climate": {
       "heater": {
@@ -116,7 +118,9 @@
             "state": {
               "Summer": "Summer",
               "Winter": "Winter",
-              "Off": "Off"
+              "Off": "Off",
+              "Party": "Party",
+              "Vacation": "Vacation"
             }
           }
         }

--- a/custom_components/kospel/switch.py
+++ b/custom_components/kospel/switch.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN, get_device_info, get_device_identifier
 from .coordinator import KospelDataUpdateCoordinator
 
-from kospel_cmi.registers.enums import ManualMode, WaterHeaterEnabled
+from kospel_cmi.registers.enums import ManualMode
 from kospel_cmi.controller.api import HeaterController
 
 
@@ -22,13 +22,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Kospel switch platform."""
     coordinator: KospelDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-
-    entities = [
-        KospelManualModeSwitch(coordinator, entry),
-        KospelWaterHeaterSwitch(coordinator, entry),
-    ]
-
-    async_add_entities(entities)
+    async_add_entities([KospelManualModeSwitch(coordinator, entry)])
 
 
 class KospelSwitchEntity(CoordinatorEntity[KospelDataUpdateCoordinator], SwitchEntity):
@@ -89,48 +83,6 @@ class KospelManualModeSwitch(KospelSwitchEntity):
         """Turn manual mode off."""
         controller: HeaterController = self.coordinator.data
         controller.is_manual_mode_enabled = ManualMode.DISABLED
-        await controller.save()
-        self.async_write_ha_state()
-        await self.coordinator.async_request_refresh()
-
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        self.async_write_ha_state()
-
-
-class KospelWaterHeaterSwitch(KospelSwitchEntity):
-    """Representation of a Kospel water heater switch."""
-
-    def __init__(
-        self,
-        coordinator: KospelDataUpdateCoordinator,
-        entry: ConfigEntry,
-    ) -> None:
-        """Initialize the water heater switch."""
-        super().__init__(coordinator, entry, "water_heater", "water_heater")
-
-    @property
-    def is_on(self) -> bool:
-        """Return if water heater is enabled."""
-        controller: HeaterController = self.coordinator.data
-        water_heater = getattr(controller, "is_water_heater_enabled", None)
-        if water_heater is None:
-            return False
-        # WaterHeaterEnabled is an enum, check if it's ENABLED
-        return water_heater == WaterHeaterEnabled.ENABLED
-
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn water heater on."""
-        controller: HeaterController = self.coordinator.data
-        controller.is_water_heater_enabled = WaterHeaterEnabled.ENABLED
-        await controller.save()
-        self.async_write_ha_state()
-        await self.coordinator.async_request_refresh()
-
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn water heater off."""
-        controller: HeaterController = self.coordinator.data
-        controller.is_water_heater_enabled = WaterHeaterEnabled.DISABLED
         await controller.save()
         self.async_write_ha_state()
         await self.coordinator.async_request_refresh()

--- a/custom_components/kospel/translations/pl.json
+++ b/custom_components/kospel/translations/pl.json
@@ -37,8 +37,10 @@
       }
     },
     "switch": {
-      "manual_mode": { "name": "Tryb ręczny" },
-      "water_heater": { "name": "Podgrzewacz wody" }
+      "manual_mode": { "name": "Tryb ręczny" }
+    },
+    "water_heater": {
+      "dhw": { "name": "Ciepła woda użytkowa" }
     },
     "climate": {
       "heater": {
@@ -48,7 +50,9 @@
             "state": {
               "Summer": "Lato",
               "Winter": "Zima",
-              "Off": "Wyłączony"
+              "Off": "Wyłączony",
+              "Party": "Impreza",
+              "Vacation": "Wakacje"
             }
           }
         }

--- a/custom_components/kospel/water_heater.py
+++ b/custom_components/kospel/water_heater.py
@@ -1,0 +1,138 @@
+"""Water heater entity for Kospel integration (CWU / DHW)."""
+
+import logging
+from typing import Any
+
+from homeassistant.components.water_heater import (
+    WaterHeaterEntity,
+    WaterHeaterEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, get_device_info, get_device_identifier
+from .coordinator import KospelDataUpdateCoordinator
+
+from kospel_cmi.registers.enums import WaterHeaterEnabled
+from kospel_cmi.controller.api import HeaterController
+
+_LOGGER = logging.getLogger(__name__)
+
+# HA water_heater operation modes (from homeassistant.const)
+STATE_ECO = "eco"
+STATE_PERFORMANCE = "performance"
+STATE_OFF = "off"
+
+OPERATION_LIST = [STATE_ECO, STATE_PERFORMANCE]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Kospel water heater platform."""
+    coordinator: KospelDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([KospelWaterHeaterEntity(coordinator)])
+
+
+class KospelWaterHeaterEntity(
+    CoordinatorEntity[KospelDataUpdateCoordinator], WaterHeaterEntity
+):
+    """Representation of a Kospel domestic hot water (CWU/DHW) entity."""
+
+    _attr_has_entity_name = True
+    _attr_name = None
+    _attr_translation_key = "dhw"
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_operation_list = OPERATION_LIST
+    _attr_min_temp = 30.0
+    _attr_max_temp = 65.0
+    _attr_supported_features = (
+        WaterHeaterEntityFeature.TARGET_TEMPERATURE
+        | WaterHeaterEntityFeature.OPERATION_MODE
+        | WaterHeaterEntityFeature.ON_OFF
+    )
+
+    def __init__(self, coordinator: KospelDataUpdateCoordinator) -> None:
+        """Initialize the water heater entity."""
+        super().__init__(coordinator)
+        device_id = get_device_identifier(coordinator.entry)
+        self._attr_unique_id = f"{device_id}_water_heater"
+        self._attr_device_info = get_device_info(coordinator.entry)
+        # Track operation mode locally (device has no CWU mode register)
+        self._current_operation = STATE_ECO
+
+    def _get_controller(self) -> HeaterController:
+        """Return the heater controller from coordinator data."""
+        return self.coordinator.data
+
+    @property
+    def current_temperature(self) -> float | None:
+        """Return the current water temperature."""
+        controller = self._get_controller()
+        return getattr(controller, "water_current_temperature", None)
+
+    @property
+    def target_temperature(self) -> float | None:
+        """Return the target temperature for the current operation mode."""
+        controller = self._get_controller()
+        if self._current_operation == STATE_ECO:
+            return getattr(controller, "cwu_temperature_economy", None)
+        return getattr(controller, "cwu_temperature_comfort", None)
+
+    @property
+    def current_operation(self) -> str:
+        """Return the current operation mode."""
+        controller = self._get_controller()
+        if getattr(controller, "is_water_heater_enabled", WaterHeaterEnabled.DISABLED) == WaterHeaterEnabled.DISABLED:
+            return STATE_OFF
+        return self._current_operation
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self.coordinator.last_update_success
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Set new target temperature."""
+        controller = self._get_controller()
+        temperature = kwargs.get("temperature")
+        if temperature is not None:
+            if self._current_operation == STATE_ECO:
+                controller.cwu_temperature_economy = temperature
+            else:
+                controller.cwu_temperature_comfort = temperature
+            await controller.save()
+            self.async_write_ha_state()
+            await self.coordinator.async_request_refresh()
+
+    async def async_set_operation_mode(self, operation_mode: str) -> None:
+        """Set new operation mode."""
+        _LOGGER.debug("Setting operation mode to %s", operation_mode)
+        if operation_mode in OPERATION_LIST:
+            self._current_operation = operation_mode
+            self.async_write_ha_state()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn water heater on."""
+        controller = self._get_controller()
+        controller.is_water_heater_enabled = WaterHeaterEnabled.ENABLED
+        await controller.save()
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn water heater off."""
+        controller = self._get_controller()
+        controller.is_water_heater_enabled = WaterHeaterEnabled.DISABLED
+        await controller.save()
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self.async_write_ha_state()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license-files = ["LICENSE*"]
 requires-python = ">=3.11"
 dependencies = [
     "aiohttp>=3.13.3",
-    "kospel-cmi-lib==0.1.0a6",
+    "kospel-cmi-lib==0.1.0a7",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,8 +68,10 @@ def sample_registers() -> Dict[str, str]:
         "0b66": "9001",
         # Register 0b67 - CWU temperature comfort (450 = 45.0°C)
         "0b67": "c201",
-        # Register 0b8a - Pressure (5000 = 50.0)
-        "0b8a": "8813",
+        # Register 0b4a - Water current temperature (420 = 42.0°C)
+        "0b4a": "a401",
+        # Register 0b4e - Pressure (500 = 5.00 bar, scaled_x100)
+        "0b4e": "f401",
         # Additional registers with edge cases
         "0b00": "0000",  # Zero value
         "0b01": "ff7f",  # 32767 (max positive)

--- a/tests/integration/test_water_heater_registers.py
+++ b/tests/integration/test_water_heater_registers.py
@@ -1,0 +1,38 @@
+"""Integration tests for water heater related registers (alpha.7)."""
+
+import pytest
+
+from kospel_cmi.controller.api import HeaterController
+
+
+class TestWaterHeaterRegisters:
+    """Tests for water_current_temperature and pressure decoding."""
+
+    @pytest.mark.asyncio
+    async def test_water_current_temperature_decoded(
+        self, heater_controller_with_registers: HeaterController
+    ) -> None:
+        """water_current_temperature is decoded from register 0b4a."""
+        controller = heater_controller_with_registers
+        assert hasattr(controller, "water_current_temperature")
+        # sample_registers has 0b4a: "a401" = 420 = 42.0°C
+        assert controller.water_current_temperature == 42.0
+
+    @pytest.mark.asyncio
+    async def test_pressure_decoded_from_0b4e(
+        self, heater_controller_with_registers: HeaterController
+    ) -> None:
+        """pressure is decoded from register 0b4e (scaled_x100)."""
+        controller = heater_controller_with_registers
+        assert hasattr(controller, "pressure")
+        # sample_registers has 0b4e: "f401" = 500 = 5.00 bar
+        assert controller.pressure == 5.0
+
+    @pytest.mark.asyncio
+    async def test_cwu_temperatures_decoded(
+        self, heater_controller_with_registers: HeaterController
+    ) -> None:
+        """cwu_temperature_economy and cwu_temperature_comfort are decoded."""
+        controller = heater_controller_with_registers
+        assert controller.cwu_temperature_economy == 40.0
+        assert controller.cwu_temperature_comfort == 45.0

--- a/uv.lock
+++ b/uv.lock
@@ -397,7 +397,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.3" },
-    { name = "kospel-cmi-lib", specifier = "==0.1.0a6" },
+    { name = "kospel-cmi-lib", specifier = "==0.1.0a7" },
 ]
 
 [package.metadata.requires-dev]
@@ -433,7 +433,7 @@ wheels = [
 
 [[package]]
 name = "kospel-cmi-lib"
-version = "0.1.0a6"
+version = "0.1.0a7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -441,9 +441,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/37/3d/107e149eaebb7893612f0075311fad04f9db0b590613d36d60212b98746c/kospel_cmi_lib-0.1.0a6.tar.gz", hash = "sha256:652e626368f974ca962ab14c3a58f18a9aa80c5de67d1b75aa1742a78bc552de", size = 33618, upload-time = "2026-03-07T16:23:01.543Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/f8/3b85c190804dd47bc711a55f7d232f662200e80051184739d31550924c70/kospel_cmi_lib-0.1.0a7.tar.gz", hash = "sha256:6d808234ba07c312244a5f24020890528a4f121b65b506122a68c5652c6a3b5a", size = 34449, upload-time = "2026-03-08T10:10:30.092Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/05/903e5f308030dff22956baa0b2f4b90e9cae3c18c455a1a56b5ad534f539/kospel_cmi_lib-0.1.0a6-py3-none-any.whl", hash = "sha256:8cd7e6a7c9697b6ee3a0e0e1ed9b7e5f7f72b1e6621214709c3bbe13975314a9", size = 46042, upload-time = "2026-03-07T16:23:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/95/a3e16f33c4df866844ff5c6c5da41e780e1a7f495c6c75c8b2df1b953797/kospel_cmi_lib-0.1.0a7-py3-none-any.whl", hash = "sha256:735b7fbc3467835d195fd390b432d9a27e34191ed9dc128f4db17948d42dccd3", size = 47019, upload-time = "2026-03-08T10:10:28.499Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR adds the `water_heater` platform for domestic hot water (CWU/DHW) control and extends the climate entity with Party and Vacation preset modes. It aligns the integration with the pattern used by other boiler integrations (Viessmann, Atag): one device with climate (CO) and water_heater (CWU) entities.

**Requires:** `kospel-cmi-lib>=0.1.0a7`

## Changes

### New: water_heater platform

- **`custom_components/kospel/water_heater.py`** – New platform for CWU control
  - `current_temperature` from `water_current_temperature` (register 0b4a)
  - `target_temperature` from `cwu_temperature_economy` (eco) or `cwu_temperature_comfort` (performance)
  - `operation_list`: `["eco", "performance"]`
  - `supported_features`: `TARGET_TEMPERATURE` | `OPERATION_MODE` | `ON_OFF`
  - `async_set_temperature`, `async_set_operation_mode`, `async_turn_on`, `async_turn_off`

### Removed: switch for CWU

- **`KospelWaterHeaterSwitch`** removed – CWU on/off is now handled by the water_heater entity
- **`KospelManualModeSwitch`** kept

### Extended: climate presets

- **`preset_modes`** extended with `"Party"` and `"Vacation"`
- Read logic: Vacation > Party > heater_mode (Summer/Winter/Off)
- Write logic: sets `is_vacation_mode_enabled` / `is_party_mode_enabled` and clears the other when switching

### Dependencies

- `kospel-cmi-lib`: `0.1.0a6` → `0.1.0a7`
  - Uses `water_current_temperature` (0b4a)
  - Uses `pressure` from register 0b4e (scaled_x100)

### Translations

- Added `entity.water_heater.dhw` (EN: "Domestic Hot Water", PL: "Ciepła woda użytkowa")
- Removed `entity.switch.water_heater`
- Added preset translations for Party (PL: "Impreza") and Vacation (PL: "Wakacje")

### Tests

- `sample_registers` updated for alpha.7: pressure 0b4e, water_current_temperature 0b4a
- New `tests/integration/test_water_heater_registers.py` – checks decoding of water heater registers

## Breaking changes

- **Switch CWU removed** – Users who relied on `switch.water_heater` should use `water_heater.turn_on` / `water_heater.turn_off` instead
- **kospel-cmi-lib 0.1.0a7 required** – Older versions will fail due to registry changes (pressure register, new attributes)

## Testing

```bash
uv sync --all-groups
uv run pytest tests/ -v
```

All 38 tests pass.
