### PR TITLE
 Align with kospel-cmi-lib alpha 9

### DIFF
--- a/custom_components/kospel/climate.py
+++ b/custom_components/kospel/climate.py
@@ -87,7 +87,7 @@ class KospelClimateEntity(
 
     @property
     def target_temperature(self) -> float | None:
-        """Return the effective target temperature (room_setpoint for CO)."""
+        """Return the target temperature (always from room_setpoint)."""
         controller: HeaterController = self.coordinator.data
         return getattr(controller, "room_setpoint", None)
 
@@ -137,8 +137,7 @@ class KospelClimateEntity(
         controller: HeaterController = self.coordinator.data
         temperature = kwargs.get("temperature")
         if temperature is not None:
-            controller.manual_temperature = temperature
-            await controller.save()
+            await controller.set_manual_heating(temperature)
             self.async_write_ha_state()
             await self.coordinator.async_request_refresh()
 

--- a/custom_components/kospel/manifest.json
+++ b/custom_components/kospel/manifest.json
@@ -8,7 +8,7 @@
   "dependencies": ["http", "network"],
   "requirements": [
     "aiohttp>=3.13.3",
-    "kospel-cmi-lib==0.1.0a8"
+    "kospel-cmi-lib==0.1.0a9"
   ],
   "codeowners": ["@JanKrl"],
   "integration_type": "hub",

--- a/custom_components/kospel/water_heater.py
+++ b/custom_components/kospel/water_heater.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN, get_device_info, get_device_identifier
 from .coordinator import KospelDataUpdateCoordinator
 
-from kospel_cmi.registers.enums import WaterHeaterEnabled
+from kospel_cmi.registers.enums import CwuMode, WaterHeaterEnabled
 from kospel_cmi.controller.api import HeaterController
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,7 +26,20 @@ STATE_ECO = "eco"
 STATE_PERFORMANCE = "performance"
 STATE_OFF = "off"
 
-OPERATION_LIST = [STATE_ECO, STATE_PERFORMANCE]
+OPERATION_LIST = [STATE_ECO, STATE_PERFORMANCE, STATE_OFF]
+
+# CwuMode (0=economy, 1=anti-freeze, 2=comfort) to HA operation mode
+_CWU_MODE_TO_HA: dict[int, str] = {
+    CwuMode.ECONOMY: STATE_ECO,
+    CwuMode.ANTI_FREEZE: STATE_OFF,
+    CwuMode.COMFORT: STATE_PERFORMANCE,
+}
+
+_HA_TO_CWU_MODE: dict[str, CwuMode] = {
+    STATE_ECO: CwuMode.ECONOMY,
+    STATE_PERFORMANCE: CwuMode.COMFORT,
+    STATE_OFF: CwuMode.ANTI_FREEZE,
+}
 
 
 async def async_setup_entry(
@@ -63,8 +76,6 @@ class KospelWaterHeaterEntity(
         device_id = get_device_identifier(coordinator.entry)
         self._attr_unique_id = f"{device_id}_water_heater"
         self._attr_device_info = get_device_info(coordinator.entry)
-        # Track operation mode locally (device has no CWU mode register)
-        self._current_operation = STATE_ECO
 
     def _get_controller(self) -> HeaterController:
         """Return the heater controller from coordinator data."""
@@ -78,17 +89,23 @@ class KospelWaterHeaterEntity(
 
     @property
     def target_temperature(self) -> float | None:
-        """Return the effective CWU target temperature (supply_setpoint)."""
+        """Return the target temperature from the active setpoint (mode-dependent)."""
         controller = self._get_controller()
-        return getattr(controller, "supply_setpoint", None)
+        cwu_mode = getattr(controller, "cwu_mode", 0)
+        if cwu_mode == CwuMode.COMFORT:
+            return getattr(controller, "cwu_temperature_comfort", None)
+        if cwu_mode == CwuMode.ANTI_FREEZE:
+            return getattr(controller, "cwu_temperature_economy", None)
+        return getattr(controller, "cwu_temperature_economy", None)
 
     @property
     def current_operation(self) -> str:
-        """Return the current operation mode."""
+        """Return the current operation mode from device cwu_mode."""
         controller = self._get_controller()
         if getattr(controller, "is_water_heater_enabled", WaterHeaterEnabled.DISABLED) == WaterHeaterEnabled.DISABLED:
             return STATE_OFF
-        return self._current_operation
+        cwu_mode = getattr(controller, "cwu_mode", 0)
+        return _CWU_MODE_TO_HA.get(cwu_mode, STATE_ECO)
 
     @property
     def available(self) -> bool:
@@ -96,24 +113,28 @@ class KospelWaterHeaterEntity(
         return self.coordinator.last_update_success
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
-        """Set new target temperature."""
+        """Set new target temperature using mode-appropriate helper."""
         controller = self._get_controller()
         temperature = kwargs.get("temperature")
         if temperature is not None:
-            if self._current_operation == STATE_ECO:
-                controller.cwu_temperature_economy = temperature
+            operation = self.current_operation
+            if operation == STATE_PERFORMANCE:
+                await controller.set_water_comfort_temperature(temperature)
             else:
-                controller.cwu_temperature_comfort = temperature
-            await controller.save()
+                await controller.set_water_economy_temperature(temperature)
             self.async_write_ha_state()
             await self.coordinator.async_request_refresh()
 
     async def async_set_operation_mode(self, operation_mode: str) -> None:
-        """Set new operation mode."""
+        """Set new operation mode via set_water_mode."""
         _LOGGER.debug("Setting operation mode to %s", operation_mode)
         if operation_mode in OPERATION_LIST:
-            self._current_operation = operation_mode
-            self.async_write_ha_state()
+            cwu_mode = _HA_TO_CWU_MODE.get(operation_mode)
+            if cwu_mode is not None:
+                controller = self._get_controller()
+                await controller.set_water_mode(cwu_mode)
+                self.async_write_ha_state()
+                await self.coordinator.async_request_refresh()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn water heater on."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license-files = ["LICENSE*"]
 requires-python = ">=3.11"
 dependencies = [
     "aiohttp>=3.13.3",
-    "kospel-cmi-lib==0.1.0a8",
+    "kospel-cmi-lib==0.1.0a9",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -69,3 +69,6 @@ precision = 2
 show_missing = true
 skip_covered = false
 fail_under = 0
+
+[tool.uv.sources]
+kospel-cmi-lib = { path = "../kospel-cmi-lib" }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,6 +74,10 @@ def sample_registers() -> Dict[str, str]:
         "0b2f": "c201",
         # Register 0b31 - Room setpoint CO (220 = 22.0°C)
         "0b31": "dc00",
+        # Register 0b30 - CWU mode (0=economy, 1=anti-freeze, 2=comfort)
+        "0b30": "0000",
+        # Register 0b32 - Room mode (64=manual, selects manual_temperature)
+        "0b32": "4000",
         # Register 0b4e - Pressure (500 = 5.00 bar, scaled_x100)
         "0b4e": "f401",
         # Additional registers with edge cases

--- a/tests/test_climate_entity.py
+++ b/tests/test_climate_entity.py
@@ -121,7 +121,6 @@ class TestClimateTargetTemperature:
         result = climate_entity.target_temperature
         assert result is None
 
-
 class TestClimateSupportedFeatures:
     """Tests for supported_features (TARGET_TEMPERATURE only when manual mode)."""
 
@@ -166,19 +165,18 @@ class TestClimateSetTemperature:
         mock_controller.save.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_set_temperature_writes_when_manual_mode_on(
+    async def test_set_temperature_calls_set_manual_heating_when_manual_mode_on(
         self, climate_entity, mock_coordinator
     ) -> None:
-        """async_set_temperature writes manual_temperature when manual mode is on."""
+        """async_set_temperature calls set_manual_heating when manual mode is on."""
         mock_controller = MagicMock()
         mock_controller.heater_mode = HeaterMode.MANUAL
-        mock_controller.save = AsyncMock()
+        mock_controller.set_manual_heating = AsyncMock(return_value=True)
         mock_coordinator.async_request_refresh = AsyncMock()
         mock_coordinator.data = mock_controller
         climate_entity.async_write_ha_state = MagicMock()
 
         await climate_entity.async_set_temperature(temperature=25.0)
 
-        assert mock_controller.manual_temperature == 25.0
-        mock_controller.save.assert_called_once()
+        mock_controller.set_manual_heating.assert_called_once_with(25.0)
         mock_coordinator.async_request_refresh.assert_called_once()

--- a/tests/test_water_heater_entity.py
+++ b/tests/test_water_heater_entity.py
@@ -1,9 +1,11 @@
-"""Tests for Kospel water heater entity (target_temperature uses supply_setpoint)."""
+"""Tests for Kospel water heater entity (target_temperature, cwu_mode, set_water_*)."""
 
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+
+from kospel_cmi.registers.enums import CwuMode
 
 # Mock homeassistant before importing integration modules.
 class _HAModule:
@@ -61,7 +63,12 @@ sys.modules["homeassistant.components.water_heater"].WaterHeaterEntity = (
     _WaterHeaterEntityBase
 )
 
-from custom_components.kospel.water_heater import KospelWaterHeaterEntity
+from custom_components.kospel.water_heater import (
+    KospelWaterHeaterEntity,
+    STATE_ECO,
+    STATE_OFF,
+    STATE_PERFORMANCE,
+)
 
 
 @pytest.fixture
@@ -82,24 +89,173 @@ def water_heater_entity(mock_coordinator):
 
 
 class TestWaterHeaterTargetTemperature:
-    """Tests for target_temperature (supply_setpoint for CWU)."""
+    """Tests for target_temperature (mode-dependent setpoints)."""
 
-    def test_target_temperature_returns_supply_setpoint(
+    def test_target_temperature_returns_economy_setpoint_when_economy_mode(
         self, water_heater_entity, mock_coordinator
     ) -> None:
-        """target_temperature returns supply_setpoint from controller."""
+        """target_temperature returns cwu_temperature_economy when cwu_mode is economy."""
         mock_controller = MagicMock()
-        mock_controller.supply_setpoint = 45.0
+        mock_controller.cwu_mode = CwuMode.ECONOMY
+        mock_controller.cwu_temperature_economy = 40.0
+        mock_controller.cwu_temperature_comfort = 45.0
+        mock_coordinator.data = mock_controller
+
+        assert water_heater_entity.target_temperature == 40.0
+
+    def test_target_temperature_returns_comfort_setpoint_when_comfort_mode(
+        self, water_heater_entity, mock_coordinator
+    ) -> None:
+        """target_temperature returns cwu_temperature_comfort when cwu_mode is comfort."""
+        mock_controller = MagicMock()
+        mock_controller.cwu_mode = CwuMode.COMFORT
+        mock_controller.cwu_temperature_economy = 40.0
+        mock_controller.cwu_temperature_comfort = 45.0
         mock_coordinator.data = mock_controller
 
         assert water_heater_entity.target_temperature == 45.0
 
-    def test_target_temperature_returns_none_when_supply_setpoint_missing(
+    def test_target_temperature_returns_economy_setpoint_when_anti_freeze_mode(
         self, water_heater_entity, mock_coordinator
     ) -> None:
-        """target_temperature returns None when supply_setpoint not in controller."""
-        mock_controller = MagicMock(spec=[])  # No supply_setpoint
+        """target_temperature returns cwu_temperature_economy when cwu_mode is anti-freeze."""
+        mock_controller = MagicMock()
+        mock_controller.cwu_mode = CwuMode.ANTI_FREEZE
+        mock_controller.cwu_temperature_economy = 40.0
+        mock_coordinator.data = mock_controller
+
+        assert water_heater_entity.target_temperature == 40.0
+
+    def test_target_temperature_returns_none_when_setpoint_missing(
+        self, water_heater_entity, mock_coordinator
+    ) -> None:
+        """target_temperature returns None when setpoint not in controller."""
+        mock_controller = MagicMock(spec=[])  # No cwu_temperature_* attributes
         mock_coordinator.data = mock_controller
 
         result = water_heater_entity.target_temperature
         assert result is None
+
+
+class TestWaterHeaterCurrentOperation:
+    """Tests for current_operation (from cwu_mode)."""
+
+    def test_current_operation_eco_when_cwu_mode_economy(
+        self, water_heater_entity, mock_coordinator
+    ) -> None:
+        """current_operation returns eco when cwu_mode is economy."""
+        from kospel_cmi.registers.enums import WaterHeaterEnabled
+
+        mock_controller = MagicMock()
+        mock_controller.is_water_heater_enabled = WaterHeaterEnabled.ENABLED
+        mock_controller.cwu_mode = CwuMode.ECONOMY
+        mock_coordinator.data = mock_controller
+
+        assert water_heater_entity.current_operation == STATE_ECO
+
+    def test_current_operation_off_when_water_heater_disabled(
+        self, water_heater_entity, mock_coordinator
+    ) -> None:
+        """current_operation returns off when water heater is disabled."""
+        from kospel_cmi.registers.enums import WaterHeaterEnabled
+
+        mock_controller = MagicMock()
+        mock_controller.is_water_heater_enabled = WaterHeaterEnabled.DISABLED
+        mock_controller.cwu_mode = CwuMode.ECONOMY
+        mock_coordinator.data = mock_controller
+
+        assert water_heater_entity.current_operation == STATE_OFF
+
+    def test_current_operation_performance_when_cwu_mode_comfort(
+        self, water_heater_entity, mock_coordinator
+    ) -> None:
+        """current_operation returns performance when cwu_mode is comfort."""
+        from kospel_cmi.registers.enums import WaterHeaterEnabled
+
+        mock_controller = MagicMock()
+        mock_controller.is_water_heater_enabled = WaterHeaterEnabled.ENABLED
+        mock_controller.cwu_mode = CwuMode.COMFORT
+        mock_coordinator.data = mock_controller
+
+        assert water_heater_entity.current_operation == STATE_PERFORMANCE
+
+
+class TestWaterHeaterSetOperationMode:
+    """Tests for async_set_operation_mode (calls set_water_mode)."""
+
+    @pytest.mark.asyncio
+    async def test_set_operation_mode_calls_set_water_mode(
+        self, water_heater_entity, mock_coordinator
+    ) -> None:
+        """async_set_operation_mode calls set_water_mode with correct CwuMode."""
+        mock_controller = MagicMock()
+        mock_controller.is_water_heater_enabled = MagicMock()
+        mock_controller.set_water_mode = AsyncMock(return_value=True)
+        mock_coordinator.data = mock_controller
+        mock_coordinator.async_request_refresh = AsyncMock()
+        water_heater_entity.async_write_ha_state = MagicMock()
+
+        await water_heater_entity.async_set_operation_mode(STATE_ECO)
+
+        mock_controller.set_water_mode.assert_called_once_with(CwuMode.ECONOMY)
+
+    @pytest.mark.asyncio
+    async def test_set_operation_mode_comfort_calls_set_water_mode(
+        self, water_heater_entity, mock_coordinator
+    ) -> None:
+        """async_set_operation_mode(performance) calls set_water_mode(COMFORT)."""
+        mock_controller = MagicMock()
+        mock_controller.set_water_mode = AsyncMock(return_value=True)
+        mock_coordinator.data = mock_controller
+        mock_coordinator.async_request_refresh = AsyncMock()
+        water_heater_entity.async_write_ha_state = MagicMock()
+
+        await water_heater_entity.async_set_operation_mode(STATE_PERFORMANCE)
+
+        mock_controller.set_water_mode.assert_called_once_with(CwuMode.COMFORT)
+
+
+class TestWaterHeaterSetTemperature:
+    """Tests for async_set_temperature (calls set_water_*_temperature)."""
+
+    @pytest.mark.asyncio
+    async def test_set_temperature_economy_calls_set_water_economy_temperature(
+        self, water_heater_entity, mock_coordinator
+    ) -> None:
+        """async_set_temperature calls set_water_economy_temperature when in eco mode."""
+        from kospel_cmi.registers.enums import WaterHeaterEnabled
+
+        mock_controller = MagicMock()
+        mock_controller.is_water_heater_enabled = WaterHeaterEnabled.ENABLED
+        mock_controller.cwu_mode = CwuMode.ECONOMY
+        mock_controller.set_water_economy_temperature = AsyncMock(return_value=True)
+        mock_controller.set_water_comfort_temperature = AsyncMock(return_value=True)
+        mock_coordinator.data = mock_controller
+        mock_coordinator.async_request_refresh = AsyncMock()
+        water_heater_entity.async_write_ha_state = MagicMock()
+
+        await water_heater_entity.async_set_temperature(temperature=38.0)
+
+        mock_controller.set_water_economy_temperature.assert_called_once_with(38.0)
+        mock_controller.set_water_comfort_temperature.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_set_temperature_comfort_calls_set_water_comfort_temperature(
+        self, water_heater_entity, mock_coordinator
+    ) -> None:
+        """async_set_temperature calls set_water_comfort_temperature when in performance mode."""
+        from kospel_cmi.registers.enums import WaterHeaterEnabled
+
+        mock_controller = MagicMock()
+        mock_controller.is_water_heater_enabled = WaterHeaterEnabled.ENABLED
+        mock_controller.cwu_mode = CwuMode.COMFORT
+        mock_controller.set_water_economy_temperature = AsyncMock(return_value=True)
+        mock_controller.set_water_comfort_temperature = AsyncMock(return_value=True)
+        mock_coordinator.data = mock_controller
+        mock_coordinator.async_request_refresh = AsyncMock()
+        water_heater_entity.async_write_ha_state = MagicMock()
+
+        await water_heater_entity.async_set_temperature(temperature=45.0)
+
+        mock_controller.set_water_comfort_temperature.assert_called_once_with(45.0)
+        mock_controller.set_water_economy_temperature.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -397,7 +397,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.3" },
-    { name = "kospel-cmi-lib", specifier = "==0.1.0a8" },
+    { name = "kospel-cmi-lib", directory = "../kospel-cmi-lib" },
 ]
 
 [package.metadata.requires-dev]
@@ -433,17 +433,30 @@ wheels = [
 
 [[package]]
 name = "kospel-cmi-lib"
-version = "0.1.0a8"
-source = { registry = "https://pypi.org/simple" }
+version = "0.1.0a2"
+source = { directory = "../kospel-cmi-lib" }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp" },
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/7c/b17b32c69f733a576964dffae6c7965f23cb074fedbee4ed15e7dbfa3f2a/kospel_cmi_lib-0.1.0a8.tar.gz", hash = "sha256:7f8265252ed162613219a361d84dc7856dc71e80eba0b09799b0bcfe19ff4d12", size = 34679, upload-time = "2026-03-08T12:54:57.739Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/00/75b653333d57db5bd2baceac57eea76ab5654df46485133e7afecbbbda8a/kospel_cmi_lib-0.1.0a8-py3-none-any.whl", hash = "sha256:08422aace861977dcd57f98e8ba6dfe186343700e764a14fc1748a39fd546ed5", size = 47370, upload-time = "2026-03-08T12:54:56.601Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "aiofiles", specifier = ">=23.0.0" },
+    { name = "aiohttp", specifier = ">=3.9.0" },
+    { name = "pydantic", specifier = ">=2.11.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "aioresponses", specifier = ">=0.7.8" },
+    { name = "coverage", extras = ["toml"], specifier = ">=7.13.2" },
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR updates ha-kospel-cmi to use [kospel-cmi-lib 0.1.0a9](https://github.com/JanKrl/kospel-cmi-lib/pull/19), adopting the new helper methods and `CwuMode` enum. It fixes the manual mode target temperature issue (stuck at 7°C) and properly persists water heater operation mode to the device.

## Problem

When in manual mode, the target temperature set via the climate widget was not applied. The heater firmware ignored `manual_temperature` (register 0b8d) unless `room_mode=64` was also set. The manufacturer's UI showed the temperature stuck at 7°C.

## Solution

kospel-cmi-lib alpha 9 (PR #19) adds:

- **`set_manual_heating(temperature)`** — Atomically sets `heater_mode=MANUAL`, `manual_temperature`, and injects `room_mode=64` so the firmware uses register 0b8d
- **`set_water_mode(CwuMode)`** — Sets CWU mode (economy, anti-freeze, comfort)
- **`set_water_comfort_temperature(temp)`** / **`set_water_economy_temperature(temp)`** — CWU temperature setters
- **`room_mode`** (0b32) and **`cwu_mode`** (0b30) registers

## Changes

### Climate entity

- **`async_set_temperature`**: Uses `await controller.set_manual_heating(temperature)` instead of raw `manual_temperature` + `save()`
- **`target_temperature`**: Always reads from `room_setpoint` (setpoint register)

### Water heater entity

- **`CwuMode`** import and mode mapping (eco ↔ ECONOMY, performance ↔ COMFORT, off ↔ ANTI_FREEZE)
- **`operation_list`**: Added `off` (anti-freeze) mode
- **`current_operation`**: Reads from `controller.cwu_mode` instead of local state
- **`target_temperature`**: Mode-dependent setpoints (`cwu_temperature_economy`, `cwu_temperature_comfort`)
- **`async_set_operation_mode`**: Persists via `await controller.set_water_mode(cwu_mode)`
- **`async_set_temperature`**: Uses `set_water_economy_temperature` / `set_water_comfort_temperature`

### Dependencies

- Bump `kospel-cmi-lib` from 0.1.0a8 to 0.1.0a9 in `pyproject.toml` and `manifest.json`

### Tests

- Added `0b30` (cwu_mode) and `0b32` (room_mode) to `sample_registers` fixture
- Updated climate tests: assert `set_manual_heating` called; removed manual-mode target temp test
- Added water heater tests: `current_operation` from cwu_mode, `set_operation_mode`, `set_temperature`, mode-dependent `target_temperature`

## Testing

All 57 tests pass.
