### PR TITLE
Upgrade kospel-cmi-lib to 0.1.0a10 and fix climate target temperature UX

### DIFF
--- a/custom_components/kospel/climate.py
+++ b/custom_components/kospel/climate.py
@@ -75,19 +75,17 @@ class KospelClimateEntity(
 
     @property
     def supported_features(self) -> int:
-        """Return supported features; target temperature only when manual mode is on."""
-        base = (
+        """Return supported features; target temperature always shown, but only settable in manual mode."""
+        return (
             ClimateEntityFeature.PRESET_MODE
             | ClimateEntityFeature.TURN_ON
             | ClimateEntityFeature.TURN_OFF
+            | ClimateEntityFeature.TARGET_TEMPERATURE
         )
-        if self._is_manual_mode:
-            base |= ClimateEntityFeature.TARGET_TEMPERATURE
-        return base
 
     @property
     def target_temperature(self) -> float | None:
-        """Return the target temperature (always from room_setpoint)."""
+        """Return the target temperature (always room_setpoint)."""
         controller: HeaterController = self.coordinator.data
         return getattr(controller, "room_setpoint", None)
 

--- a/custom_components/kospel/manifest.json
+++ b/custom_components/kospel/manifest.json
@@ -8,7 +8,7 @@
   "dependencies": ["http", "network"],
   "requirements": [
     "aiohttp>=3.13.3",
-    "kospel-cmi-lib==0.1.0a9"
+    "kospel-cmi-lib==0.1.0a10"
   ],
   "codeowners": ["@JanKrl"],
   "integration_type": "hub",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license-files = ["LICENSE*"]
 requires-python = ">=3.11"
 dependencies = [
     "aiohttp>=3.13.3",
-    "kospel-cmi-lib==0.1.0a9",
+    "kospel-cmi-lib==0.1.0a10",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -69,6 +69,3 @@ precision = 2
 show_missing = true
 skip_covered = false
 fail_under = 0
-
-[tool.uv.sources]
-kospel-cmi-lib = { path = "../kospel-cmi-lib" }

--- a/tests/test_climate_entity.py
+++ b/tests/test_climate_entity.py
@@ -99,12 +99,12 @@ def climate_entity(mock_coordinator):
 
 
 class TestClimateTargetTemperature:
-    """Tests for target_temperature (room_setpoint)."""
+    """Tests for target_temperature (always room_setpoint)."""
 
     def test_target_temperature_returns_room_setpoint(
         self, climate_entity, mock_coordinator
     ) -> None:
-        """target_temperature returns room_setpoint from controller."""
+        """target_temperature always returns room_setpoint from controller."""
         mock_controller = MagicMock()
         mock_controller.room_setpoint = 22.0
         mock_coordinator.data = mock_controller
@@ -115,36 +115,28 @@ class TestClimateTargetTemperature:
         self, climate_entity, mock_coordinator
     ) -> None:
         """target_temperature returns None when room_setpoint not in controller."""
-        mock_controller = MagicMock(spec=[])  # No room_setpoint
+        mock_controller = MagicMock()
+        mock_controller.room_setpoint = None
         mock_coordinator.data = mock_controller
 
         result = climate_entity.target_temperature
         assert result is None
 
+
 class TestClimateSupportedFeatures:
-    """Tests for supported_features (TARGET_TEMPERATURE only when manual mode)."""
+    """Tests for supported_features (TARGET_TEMPERATURE always shown for display)."""
 
-    def test_supported_features_includes_target_temp_when_manual_mode_on(
+    def test_supported_features_includes_target_temp_always(
         self, climate_entity, mock_coordinator
     ) -> None:
-        """TARGET_TEMPERATURE included when manual mode is enabled."""
-        mock_controller = MagicMock()
-        mock_controller.heater_mode = HeaterMode.MANUAL
-        mock_coordinator.data = mock_controller
+        """TARGET_TEMPERATURE always included so target is displayed; only settable in manual mode."""
+        for mode in (HeaterMode.WINTER, HeaterMode.MANUAL):
+            mock_controller = MagicMock()
+            mock_controller.heater_mode = mode
+            mock_coordinator.data = mock_controller
 
-        features = climate_entity.supported_features
-        assert (features & ClimateEntityFeature.TARGET_TEMPERATURE) != 0
-
-    def test_supported_features_excludes_target_temp_when_manual_mode_off(
-        self, climate_entity, mock_coordinator
-    ) -> None:
-        """TARGET_TEMPERATURE excluded when manual mode is disabled."""
-        mock_controller = MagicMock()
-        mock_controller.heater_mode = HeaterMode.WINTER
-        mock_coordinator.data = mock_controller
-
-        features = climate_entity.supported_features
-        assert (features & ClimateEntityFeature.TARGET_TEMPERATURE) == 0
+            features = climate_entity.supported_features
+            assert (features & ClimateEntityFeature.TARGET_TEMPERATURE) != 0
 
 
 class TestClimateSetTemperature:

--- a/uv.lock
+++ b/uv.lock
@@ -397,7 +397,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.3" },
-    { name = "kospel-cmi-lib", directory = "../kospel-cmi-lib" },
+    { name = "kospel-cmi-lib", specifier = "==0.1.0a10" },
 ]
 
 [package.metadata.requires-dev]
@@ -433,30 +433,17 @@ wheels = [
 
 [[package]]
 name = "kospel-cmi-lib"
-version = "0.1.0a2"
-source = { directory = "../kospel-cmi-lib" }
+version = "0.1.0a10"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp" },
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "aiofiles", specifier = ">=23.0.0" },
-    { name = "aiohttp", specifier = ">=3.9.0" },
-    { name = "pydantic", specifier = ">=2.11.0" },
-    { name = "pyyaml", specifier = ">=6.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "aioresponses", specifier = ">=0.7.8" },
-    { name = "coverage", extras = ["toml"], specifier = ">=7.13.2" },
-    { name = "pytest", specifier = ">=9.0.2" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0" },
-    { name = "pyyaml", specifier = ">=6.0.3" },
+sdist = { url = "https://files.pythonhosted.org/packages/84/e4/69ac83e6b5bfbc5d4f30a596a5ec17eef658a79d2320bc5d15bea6773aba/kospel_cmi_lib-0.1.0a10.tar.gz", hash = "sha256:db384162611ccafdd61ee987deec87c2c0b3d61f11f4beb025c5a8c181b20784", size = 35968, upload-time = "2026-03-09T16:42:07.253Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/c7/d49e1d78bdf1b125b631abcb81e7fc2e8649573c942684687d43c059c9d2/kospel_cmi_lib-0.1.0a10-py3-none-any.whl", hash = "sha256:716b7a74bae2cbb85acba7a8bd3eab1a2d3cf48b93cca4d43b0b4a6c209d0b12", size = 48754, upload-time = "2026-03-09T16:42:06.069Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Upgrade kospel-cmi-lib to 0.1.0a10 and fix climate target temperature UX

### kospel-cmi-lib upgrade

- Bump `kospel-cmi-lib` from `0.1.0a9` to `0.1.0a10`
- Remove path override in `pyproject.toml`; use PyPI instead of local `../kospel-cmi-lib`
- Update `pyproject.toml` and `manifest.json` with the new version

**v0.1.0a10 changes:**
- Fix manual mode setting (PR #20): Manual, Party, and Vacation are sub-modes of Winter; encoder now sets bit 5 (Winter) plus the sub-mode bit so manual mode works correctly on the device
- Manual mode and CWU helper methods (PR #19): `set_manual_heating()`, `set_water_mode()`, `set_water_comfort_temperature()`, `set_water_economy_temperature()`

### Climate entity target temperature

- **Always show target temperature:** Use `room_setpoint` as target in all modes and keep `TARGET_TEMPERATURE` in `supported_features` so the climate card always shows the target
- **Only allow changes in manual mode:** `async_set_temperature` ignores changes when not in manual mode, so the target is effectively read-only in winter/summer/off
- Avoids accidental mode changes from misclicks while keeping the target visible

### Testing

- All 57 tests pass
- Climate entity tests updated for the new behavior