### PR TITLE
Fix heating indicator, slow widget, and add power sensor

### DIFF
--- a/custom_components/kospel/climate.py
+++ b/custom_components/kospel/climate.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN, get_device_info, get_device_identifier
 from .coordinator import KospelDataUpdateCoordinator
 
-from kospel_cmi.registers.enums import HeaterMode, PumpStatus
+from kospel_cmi.registers.enums import HeaterMode, HeatingStatus
 from kospel_cmi.controller.api import HeaterController
 
 _LOGGER = logging.getLogger(__name__)
@@ -96,12 +96,12 @@ class KospelClimateEntity(
 
     @property
     def hvac_action(self) -> HVACAction:
-        """HVAC action is based on whether or not CO pump is running"""
+        """HVAC action is based on whether CO heating circuit is active."""
         controller: HeaterController = self.coordinator.data
         return (
             HVACAction.HEATING
-            if getattr(controller, "is_pump_co_running", PumpStatus.IDLE)
-            == PumpStatus.RUNNING
+            if getattr(controller, "co_heating_status", HeatingStatus.IDLE)
+            == HeatingStatus.RUNNING
             else HVACAction.OFF
         )
 

--- a/custom_components/kospel/const.py
+++ b/custom_components/kospel/const.py
@@ -34,7 +34,7 @@ BACKEND_TYPE_YAML = "yaml"
 YAML_STATE_FILE_RELATIVE = "data/state.yaml"
 
 # Update intervals
-SCAN_INTERVAL = timedelta(seconds=30)
+SCAN_INTERVAL = timedelta(seconds=15)
 
 # Simulation mode constants (deprecated; migration only)
 SIMULATION_MODE_ENV_VAR = "SIMULATION_MODE"

--- a/custom_components/kospel/manifest.json
+++ b/custom_components/kospel/manifest.json
@@ -8,7 +8,7 @@
   "dependencies": ["http", "network"],
   "requirements": [
     "aiohttp>=3.13.3",
-    "kospel-cmi-lib==0.1.0a10"
+    "kospel-cmi-lib==0.1.0a11"
   ],
   "codeowners": ["@JanKrl"],
   "integration_type": "hub",

--- a/custom_components/kospel/sensor.py
+++ b/custom_components/kospel/sensor.py
@@ -6,7 +6,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfPressure, UnitOfTemperature
+from homeassistant.const import UnitOfPower, UnitOfPressure, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -47,15 +47,18 @@ async def async_setup_entry(
     # Pressure sensor
     entities.append(KospelPressureSensor(coordinator, entry))
 
-    # Status sensors: (unique_id_suffix, translation_key, setting_name)
+    # Power sensor
+    entities.append(KospelPowerSensor(coordinator, entry))
+
+    # Heating status sensors: (unique_id_suffix, setting_name)
     entities.append(
-        KospelPumpStatusSensor(
-            coordinator, entry, "pump_co", "is_pump_co_running"
+        KospelHeatingStatusSensor(
+            coordinator, entry, "co_heating", "co_heating_status"
         )
     )
     entities.append(
-        KospelPumpStatusSensor(
-            coordinator, entry, "pump_circulation", "is_pump_circulation_running"
+        KospelHeatingStatusSensor(
+            coordinator, entry, "cwu_heating", "cwu_heating_status"
         )
     )
     entities.append(KospelValvePositionSensor(coordinator, entry))
@@ -143,8 +146,34 @@ class KospelPressureSensor(KospelSensorEntity):
         self.async_write_ha_state()
 
 
-class KospelPumpStatusSensor(KospelSensorEntity):
-    """Representation of a Kospel pump status sensor."""
+class KospelPowerSensor(KospelSensorEntity):
+    """Representation of a Kospel power sensor (heating element power in kW)."""
+
+    _attr_device_class = SensorDeviceClass.POWER
+    _attr_native_unit_of_measurement = UnitOfPower.KILOWATT
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(
+        self,
+        coordinator: KospelDataUpdateCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the power sensor."""
+        super().__init__(coordinator, entry, "power", "power")
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the power value in kW."""
+        controller: HeaterController = self.coordinator.data
+        return getattr(controller, "power", None)
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self.async_write_ha_state()
+
+
+class KospelHeatingStatusSensor(KospelSensorEntity):
+    """Representation of a Kospel heating status sensor (CO or CWU circuit)."""
 
     def __init__(
         self,
@@ -153,13 +182,13 @@ class KospelPumpStatusSensor(KospelSensorEntity):
         unique_id_suffix: str,
         setting_name: str,
     ) -> None:
-        """Initialize the pump status sensor."""
+        """Initialize the heating status sensor."""
         super().__init__(coordinator, entry, unique_id_suffix, unique_id_suffix)
         self._setting_name = setting_name
 
     @property
     def native_value(self) -> str | None:
-        """Return the pump status."""
+        """Return the heating status (RUNNING, IDLE, DISABLED)."""
         controller: HeaterController = self.coordinator.data
         status = getattr(controller, self._setting_name, None)
         if status is None:

--- a/custom_components/kospel/strings.json
+++ b/custom_components/kospel/strings.json
@@ -81,18 +81,21 @@
       "room_setpoint": { "name": "Room Setpoint" },
       "supply_setpoint": { "name": "DHW Setpoint" },
       "pressure": { "name": "Pressure" },
-      "pump_co": {
-        "name": "Pump CO",
+      "power": { "name": "Power" },
+      "co_heating": {
+        "name": "CO Heating",
         "state": {
-          "Running": "Running",
-          "Idle": "Idle"
+          "running": "Running",
+          "idle": "Idle",
+          "disabled": "Disabled"
         }
       },
-      "pump_circulation": {
-        "name": "Pump Circulation",
+      "cwu_heating": {
+        "name": "CWU Heating",
         "state": {
-          "Running": "Running",
-          "Idle": "Idle"
+          "running": "Running",
+          "idle": "Idle",
+          "disabled": "Disabled"
         }
       },
       "valve_position": {

--- a/custom_components/kospel/translations/pl.json
+++ b/custom_components/kospel/translations/pl.json
@@ -13,18 +13,21 @@
       "room_setpoint": { "name": "Nastawa pokojowa" },
       "supply_setpoint": { "name": "Nastawa CWU" },
       "pressure": { "name": "Ciśnienie" },
-      "pump_co": {
-        "name": "Pompa CO",
+      "power": { "name": "Moc" },
+      "co_heating": {
+        "name": "Ogrzewanie CO",
         "state": {
-          "Running": "Praca",
-          "Idle": "Bezczynność"
+          "running": "Praca",
+          "idle": "Bezczynność",
+          "disabled": "Wyłączone"
         }
       },
-      "pump_circulation": {
-        "name": "Pompa obiegowa",
+      "cwu_heating": {
+        "name": "Ogrzewanie CWU",
         "state": {
-          "Running": "Praca",
-          "Idle": "Bezczynność"
+          "running": "Praca",
+          "idle": "Bezczynność",
+          "disabled": "Wyłączone"
         }
       },
       "valve_position": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license-files = ["LICENSE*"]
 requires-python = ">=3.11"
 dependencies = [
     "aiohttp>=3.13.3",
-    "kospel-cmi-lib==0.1.0a10",
+    "kospel-cmi-lib==0.1.0a11",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/tests/test_climate_entity.py
+++ b/tests/test_climate_entity.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from kospel_cmi.registers.enums import HeaterMode
+from kospel_cmi.registers.enums import HeaterMode, HeatingStatus
 
 # Mock homeassistant before importing integration modules.
 class _HAModule:
@@ -79,6 +79,7 @@ sys.modules["homeassistant.components.climate"] = climate_mock
 from custom_components.kospel.climate import KospelClimateEntity
 
 ClimateEntityFeature = _ClimateEntityFeature
+HVACAction = climate_mock.HVACAction
 
 
 @pytest.fixture
@@ -172,3 +173,46 @@ class TestClimateSetTemperature:
 
         mock_controller.set_manual_heating.assert_called_once_with(25.0)
         mock_coordinator.async_request_refresh.assert_called_once()
+
+
+class TestClimateHvacAction:
+    """Tests for hvac_action (heating indicator based on co_heating_status)."""
+
+    def test_hvac_action_heating_when_co_heating_status_running(
+        self, climate_entity, mock_coordinator
+    ) -> None:
+        """hvac_action returns HEATING when co_heating_status is RUNNING."""
+        mock_controller = MagicMock()
+        mock_controller.co_heating_status = HeatingStatus.RUNNING
+        mock_coordinator.data = mock_controller
+
+        assert climate_entity.hvac_action == HVACAction.HEATING
+
+    def test_hvac_action_off_when_co_heating_status_idle(
+        self, climate_entity, mock_coordinator
+    ) -> None:
+        """hvac_action returns OFF when co_heating_status is IDLE."""
+        mock_controller = MagicMock()
+        mock_controller.co_heating_status = HeatingStatus.IDLE
+        mock_coordinator.data = mock_controller
+
+        assert climate_entity.hvac_action == HVACAction.OFF
+
+    def test_hvac_action_off_when_co_heating_status_disabled(
+        self, climate_entity, mock_coordinator
+    ) -> None:
+        """hvac_action returns OFF when co_heating_status is DISABLED."""
+        mock_controller = MagicMock()
+        mock_controller.co_heating_status = HeatingStatus.DISABLED
+        mock_coordinator.data = mock_controller
+
+        assert climate_entity.hvac_action == HVACAction.OFF
+
+    def test_hvac_action_off_when_co_heating_status_missing(
+        self, climate_entity, mock_coordinator
+    ) -> None:
+        """hvac_action returns OFF when co_heating_status is missing (fallback to IDLE)."""
+        mock_controller = object()  # No co_heating_status attribute
+        mock_coordinator.data = mock_controller
+
+        assert climate_entity.hvac_action == HVACAction.OFF

--- a/uv.lock
+++ b/uv.lock
@@ -397,7 +397,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.3" },
-    { name = "kospel-cmi-lib", specifier = "==0.1.0a10" },
+    { name = "kospel-cmi-lib", specifier = "==0.1.0a11" },
 ]
 
 [package.metadata.requires-dev]
@@ -433,7 +433,7 @@ wheels = [
 
 [[package]]
 name = "kospel-cmi-lib"
-version = "0.1.0a10"
+version = "0.1.0a11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -441,9 +441,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/e4/69ac83e6b5bfbc5d4f30a596a5ec17eef658a79d2320bc5d15bea6773aba/kospel_cmi_lib-0.1.0a10.tar.gz", hash = "sha256:db384162611ccafdd61ee987deec87c2c0b3d61f11f4beb025c5a8c181b20784", size = 35968, upload-time = "2026-03-09T16:42:07.253Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/8e/22fec30e214d1a8a8a8fa9914d698f8b32ed62afe494c8649309117fff2d/kospel_cmi_lib-0.1.0a11.tar.gz", hash = "sha256:fd7acae6d73c64e0ade941d7330140fb796fb7dc76f0fe1b15191bcf4bea512a", size = 36558, upload-time = "2026-03-10T18:11:54.458Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/c7/d49e1d78bdf1b125b631abcb81e7fc2e8649573c942684687d43c059c9d2/kospel_cmi_lib-0.1.0a10-py3-none-any.whl", hash = "sha256:716b7a74bae2cbb85acba7a8bd3eab1a2d3cf48b93cca4d43b0b4a6c209d0b12", size = 48754, upload-time = "2026-03-09T16:42:06.069Z" },
+    { url = "https://files.pythonhosted.org/packages/08/06/5461962a552a12c22f72128bada57cc82eb34b6302f732a2fec810825791/kospel_cmi_lib-0.1.0a11-py3-none-any.whl", hash = "sha256:445fd3b54afbe1497f26cc8e8ebc1adc9e049148fa5879d26ce6799b7391008b", size = 49361, upload-time = "2026-03-10T18:11:52.898Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes GitHub issues #15 (heating indicator not working) and #16 (slow widget), and adds a power sensor. Requires upgrading to `kospel-cmi-lib` 0.1.0a11.

## Changes

### Issue #15: Heating indicator not working

The climate entity showed "Heating" even when the heater was idle because it used `is_pump_co_running` (register 0b51 bit 0), which does not reflect actual heating activity.

**Fix:** Use `co_heating_status` from kospel-cmi-lib 0.1.0a11, which uses bits 7 and 8 of register 0b51 and matches the manufacturer UI.

- **climate.py:** Replace `PumpStatus` / `is_pump_co_running` with `HeatingStatus` / `co_heating_status`
- **sensor.py:** Replace pump sensors with heating status sensors:
  - `pump_co` → `co_heating` (CO/radiator circuit)
  - `pump_circulation` → `cwu_heating` (CWU/tap circuit)
  - New states: `running`, `idle`, `disabled`

### Issue #16: Slow widget

The widget felt slow because the scan interval was 30 seconds.

**Fix:** Reduce `SCAN_INTERVAL` from 30s to 15s in `const.py`.

### Power sensor (new)

Add a power sensor for heating element power (kW), using the existing `power` property from the library (register 0b46).

- **sensor.py:** Add `KospelPowerSensor` with `SensorDeviceClass.POWER` and `UnitOfPower.KILOWATT`

## Breaking changes

- **Pump sensors removed:** `pump_co` and `pump_circulation` are replaced by `co_heating` and `cwu_heating`. Unique IDs change, so existing entities may be recreated.
- **Dependency:** Requires `kospel-cmi-lib==0.1.0a11` (from 0.1.0a10)

## Translations

- Updated `strings.json` and `translations/pl.json` for the new sensors and states.

## Tests

- Added 4 unit tests for `hvac_action` in `test_climate_entity.py`.
- All 60 tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes entity IDs/semantics (pump sensors replaced by heating-status sensors) and increases polling frequency, which can impact existing dashboards/automations and device load.
> 
> **Overview**
> Fixes the climate *heating indicator* by switching `hvac_action` logic from pump-running detection to the library’s `co_heating_status` (`HeatingStatus`).
> 
> Adds a new `power` sensor (kW) and replaces the two pump status sensors with `co_heating`/`cwu_heating` heating-status sensors (including new `running`/`idle`/`disabled` states and updated translations).
> 
> Speeds up updates by reducing `SCAN_INTERVAL` from 30s to 15s, and bumps the required `kospel-cmi-lib` dependency to `0.1.0a11` (lockfile and project metadata updated).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ff5788e636f7df32bbaa5cc40d4fdbe5ebb44e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->