### PR TITLE
Feature/simplify-cwu-fix-refresh-issue

### DIFF
--- a/custom_components/kospel/climate.py
+++ b/custom_components/kospel/climate.py
@@ -17,11 +17,10 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
-    CONF_REFRESH_DELAY_AFTER_SET,
-    DEFAULT_REFRESH_DELAY_AFTER_SET,
     DOMAIN,
     get_device_info,
     get_device_identifier,
+    get_refresh_delay_after_set,
 )
 from .coordinator import KospelDataUpdateCoordinator
 
@@ -128,6 +127,14 @@ class KospelClimateEntity(
             CONF_REFRESH_DELAY_AFTER_SET, DEFAULT_REFRESH_DELAY_AFTER_SET
         )
 
+    async def async_turn_on(self) -> None:
+        """Turn heater on (set to HEAT mode)."""
+        await self.async_set_hvac_mode(HVACMode.HEAT)
+
+    async def async_turn_off(self) -> None:
+        """Turn heater off."""
+        await self.async_set_hvac_mode(HVACMode.OFF)
+
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target HVAC mode."""
         _LOGGER.debug("Setting HVAC mode to %s", hvac_mode)
@@ -138,7 +145,7 @@ class KospelClimateEntity(
         )
         await controller.save()
         self.async_write_ha_state()
-        await asyncio.sleep(self._get_refresh_delay())
+        await asyncio.sleep(get_refresh_delay_after_set(self.coordinator.entry))
         await self.coordinator.async_request_refresh()
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
@@ -151,7 +158,7 @@ class KospelClimateEntity(
         if temperature is not None:
             await controller.set_manual_heating(temperature)
             self.async_write_ha_state()
-            await asyncio.sleep(self._get_refresh_delay())
+            await asyncio.sleep(get_refresh_delay_after_set(self.coordinator.entry))
             await self.coordinator.async_request_refresh()
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
@@ -161,7 +168,7 @@ class KospelClimateEntity(
         controller.heater_mode = HeaterMode(preset_mode.lower())
         await controller.save()
         self.async_write_ha_state()
-        await asyncio.sleep(self._get_refresh_delay())
+        await asyncio.sleep(get_refresh_delay_after_set(self.coordinator.entry))
         await self.coordinator.async_request_refresh()
 
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/kospel/climate.py
+++ b/custom_components/kospel/climate.py
@@ -121,12 +121,6 @@ class KospelClimateEntity(
         """Return if entity is available."""
         return self.coordinator.last_update_success
 
-    def _get_refresh_delay(self) -> float:
-        """Delay before refresh after set (from options or default)."""
-        return self.coordinator.entry.options.get(
-            CONF_REFRESH_DELAY_AFTER_SET, DEFAULT_REFRESH_DELAY_AFTER_SET
-        )
-
     async def async_turn_on(self) -> None:
         """Turn heater on (set to HEAT mode)."""
         await self.async_set_hvac_mode(HVACMode.HEAT)

--- a/custom_components/kospel/climate.py
+++ b/custom_components/kospel/climate.py
@@ -1,5 +1,6 @@
 """Climate entity for Kospel integration."""
 
+import asyncio
 import logging
 from typing import Any
 
@@ -15,7 +16,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, get_device_info, get_device_identifier
+from .const import (
+    CONF_REFRESH_DELAY_AFTER_SET,
+    DEFAULT_REFRESH_DELAY_AFTER_SET,
+    DOMAIN,
+    get_device_info,
+    get_device_identifier,
+)
 from .coordinator import KospelDataUpdateCoordinator
 
 from kospel_cmi.registers.enums import HeaterMode, HeatingStatus
@@ -115,6 +122,12 @@ class KospelClimateEntity(
         """Return if entity is available."""
         return self.coordinator.last_update_success
 
+    def _get_refresh_delay(self) -> float:
+        """Delay before refresh after set (from options or default)."""
+        return self.coordinator.entry.options.get(
+            CONF_REFRESH_DELAY_AFTER_SET, DEFAULT_REFRESH_DELAY_AFTER_SET
+        )
+
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target HVAC mode."""
         _LOGGER.debug("Setting HVAC mode to %s", hvac_mode)
@@ -125,6 +138,7 @@ class KospelClimateEntity(
         )
         await controller.save()
         self.async_write_ha_state()
+        await asyncio.sleep(self._get_refresh_delay())
         await self.coordinator.async_request_refresh()
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
@@ -137,6 +151,7 @@ class KospelClimateEntity(
         if temperature is not None:
             await controller.set_manual_heating(temperature)
             self.async_write_ha_state()
+            await asyncio.sleep(self._get_refresh_delay())
             await self.coordinator.async_request_refresh()
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
@@ -146,6 +161,7 @@ class KospelClimateEntity(
         controller.heater_mode = HeaterMode(preset_mode.lower())
         await controller.save()
         self.async_write_ha_state()
+        await asyncio.sleep(self._get_refresh_delay())
         await self.coordinator.async_request_refresh()
 
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/kospel/config_flow.py
+++ b/custom_components/kospel/config_flow.py
@@ -18,11 +18,15 @@ from .const import (
     CONF_BACKEND_TYPE,
     CONF_HEATER_IP,
     CONF_DEVICE_ID,
+    CONF_REFRESH_DELAY_AFTER_SET,
     CONF_SERIAL_NUMBER,
     CONF_SIMULATION_MODE,
+    DEFAULT_REFRESH_DELAY_AFTER_SET,
     DEFAULT_SUBNETS,
     BACKEND_TYPE_HTTP,
     BACKEND_TYPE_YAML,
+    REFRESH_DELAY_MAX,
+    REFRESH_DELAY_MIN,
     make_unique_id,
 )
 
@@ -380,3 +384,39 @@ class KospelConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         hass.config_entries.async_update_entry(entry, data=data, version=2)
         return True
+
+    @staticmethod
+    async def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> "KospelOptionsFlowHandler":
+        """Get the options flow for this handler."""
+        return KospelOptionsFlowHandler(config_entry)
+
+
+class KospelOptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
+    """Handle Kospel integration options."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage integration options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        default_delay = self.options.get(
+            CONF_REFRESH_DELAY_AFTER_SET, DEFAULT_REFRESH_DELAY_AFTER_SET
+        )
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_REFRESH_DELAY_AFTER_SET,
+                        default=default_delay,
+                    ): vol.All(
+                        vol.Coerce(float),
+                        vol.Range(min=REFRESH_DELAY_MIN, max=REFRESH_DELAY_MAX),
+                    ),
+                }
+            ),
+        )

--- a/custom_components/kospel/const.py
+++ b/custom_components/kospel/const.py
@@ -41,7 +41,6 @@ CONF_REFRESH_DELAY_AFTER_SET = "refresh_delay_after_set"
 DEFAULT_REFRESH_DELAY_AFTER_SET = 1.0  # seconds
 REFRESH_DELAY_MIN = 0.5
 REFRESH_DELAY_MAX = 5.0
-REFRESH_DELAY_STEP = 0.5
 
 # Simulation mode constants (deprecated; migration only)
 SIMULATION_MODE_ENV_VAR = "SIMULATION_MODE"
@@ -84,6 +83,22 @@ def get_device_identifier(entry: "ConfigEntry") -> str:
     if serial is not None and device_id is not None:
         return make_unique_id(serial, device_id)
     return entry.entry_id
+
+
+def get_refresh_delay_after_set(entry: "ConfigEntry") -> float:
+    """Return delay (seconds) before coordinator refresh after set operations.
+
+    Uses options when available; falls back to default for legacy entries.
+    Defensive against entry.options being None.
+
+    Args:
+        entry: Config entry for the heater.
+
+    Returns:
+        Delay in seconds (0.5 to 5.0).
+    """
+    options = entry.options or {}
+    return options.get(CONF_REFRESH_DELAY_AFTER_SET, DEFAULT_REFRESH_DELAY_AFTER_SET)
 
 
 def get_device_info(entry: "ConfigEntry") -> DeviceInfo:

--- a/custom_components/kospel/const.py
+++ b/custom_components/kospel/const.py
@@ -36,6 +36,13 @@ YAML_STATE_FILE_RELATIVE = "data/state.yaml"
 # Update intervals
 SCAN_INTERVAL = timedelta(seconds=15)
 
+# Delay before coordinator refresh after set operations (device needs time to persist).
+CONF_REFRESH_DELAY_AFTER_SET = "refresh_delay_after_set"
+DEFAULT_REFRESH_DELAY_AFTER_SET = 1.0  # seconds
+REFRESH_DELAY_MIN = 0.5
+REFRESH_DELAY_MAX = 5.0
+REFRESH_DELAY_STEP = 0.5
+
 # Simulation mode constants (deprecated; migration only)
 SIMULATION_MODE_ENV_VAR = "SIMULATION_MODE"
 

--- a/custom_components/kospel/strings.json
+++ b/custom_components/kospel/strings.json
@@ -70,6 +70,17 @@
     },
     "abort": {
       "already_configured": "Integration is already configured"
+    },
+    "options": {
+      "step": {
+        "init": {
+          "title": "Integration options",
+          "description": "Kospel devices may need time to persist changes. If the UI reverts to the previous value after switching modes, increase this delay.",
+          "data": {
+            "refresh_delay_after_set": "Delay before refresh after change (seconds)"
+          }
+        }
+      }
     }
   },
   "entity": {

--- a/custom_components/kospel/water_heater.py
+++ b/custom_components/kospel/water_heater.py
@@ -1,25 +1,15 @@
 """Water heater entity for Kospel integration (CWU / DHW)."""
 
-import asyncio
 import logging
 
-from homeassistant.components.water_heater import (
-    WaterHeaterEntity,
-    WaterHeaterEntityFeature,
-)
+from homeassistant.components.water_heater import WaterHeaterEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import (
-    CONF_REFRESH_DELAY_AFTER_SET,
-    DEFAULT_REFRESH_DELAY_AFTER_SET,
-    DOMAIN,
-    get_device_info,
-    get_device_identifier,
-)
+from .const import DOMAIN, get_device_info, get_device_identifier
 from .coordinator import KospelDataUpdateCoordinator
 
 from kospel_cmi.registers.enums import CwuMode, WaterHeaterEnabled
@@ -41,12 +31,6 @@ _CWU_MODE_TO_HA: dict[int, str] = {
     CwuMode.COMFORT: STATE_PERFORMANCE,
 }
 
-_HA_TO_CWU_MODE: dict[str, CwuMode] = {
-    STATE_ECO: CwuMode.ECONOMY,
-    STATE_PERFORMANCE: CwuMode.COMFORT,
-    STATE_OFF: CwuMode.ANTI_FREEZE,
-}
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -61,7 +45,11 @@ async def async_setup_entry(
 class KospelWaterHeaterEntity(
     CoordinatorEntity[KospelDataUpdateCoordinator], WaterHeaterEntity
 ):
-    """Representation of a Kospel domestic hot water (CWU/DHW) entity."""
+    """Representation of a Kospel domestic hot water (CWU/DHW) entity.
+
+    Read-only: displays current temperature, target temperature, and operation
+    mode. Climate entity controls main power; CWU mode is not configurable here.
+    """
 
     _attr_has_entity_name = True
     _attr_name = None
@@ -70,9 +58,7 @@ class KospelWaterHeaterEntity(
     _attr_operation_list = OPERATION_LIST
     _attr_min_temp = 30.0
     _attr_max_temp = 65.0
-    # ON_OFF and TARGET_TEMPERATURE not supported: climate controls main power,
-    # CWU setpoint temperature is not configurable via this integration.
-    _attr_supported_features = WaterHeaterEntityFeature.OPERATION_MODE
+    _attr_supported_features = 0  # Read-only: no set operations
 
     def __init__(self, coordinator: KospelDataUpdateCoordinator) -> None:
         """Initialize the water heater entity."""
@@ -115,24 +101,6 @@ class KospelWaterHeaterEntity(
     def available(self) -> bool:
         """Return if entity is available."""
         return self.coordinator.last_update_success
-
-    def _get_refresh_delay(self) -> float:
-        """Delay before refresh after set (from options or default)."""
-        return self.coordinator.entry.options.get(
-            CONF_REFRESH_DELAY_AFTER_SET, DEFAULT_REFRESH_DELAY_AFTER_SET
-        )
-
-    async def async_set_operation_mode(self, operation_mode: str) -> None:
-        """Set new operation mode via set_water_mode."""
-        _LOGGER.debug("Setting operation mode to %s", operation_mode)
-        if operation_mode in OPERATION_LIST:
-            cwu_mode = _HA_TO_CWU_MODE.get(operation_mode)
-            if cwu_mode is not None:
-                controller = self._get_controller()
-                await controller.set_water_mode(cwu_mode)
-                self.async_write_ha_state()
-                await asyncio.sleep(self._get_refresh_delay())
-                await self.coordinator.async_request_refresh()
 
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""

--- a/custom_components/kospel/water_heater.py
+++ b/custom_components/kospel/water_heater.py
@@ -1,7 +1,7 @@
 """Water heater entity for Kospel integration (CWU / DHW)."""
 
+import asyncio
 import logging
-from typing import Any
 
 from homeassistant.components.water_heater import (
     WaterHeaterEntity,
@@ -13,7 +13,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, get_device_info, get_device_identifier
+from .const import (
+    CONF_REFRESH_DELAY_AFTER_SET,
+    DEFAULT_REFRESH_DELAY_AFTER_SET,
+    DOMAIN,
+    get_device_info,
+    get_device_identifier,
+)
 from .coordinator import KospelDataUpdateCoordinator
 
 from kospel_cmi.registers.enums import CwuMode, WaterHeaterEnabled
@@ -64,11 +70,9 @@ class KospelWaterHeaterEntity(
     _attr_operation_list = OPERATION_LIST
     _attr_min_temp = 30.0
     _attr_max_temp = 65.0
-    _attr_supported_features = (
-        WaterHeaterEntityFeature.TARGET_TEMPERATURE
-        | WaterHeaterEntityFeature.OPERATION_MODE
-        | WaterHeaterEntityFeature.ON_OFF
-    )
+    # ON_OFF and TARGET_TEMPERATURE not supported: climate controls main power,
+    # CWU setpoint temperature is not configurable via this integration.
+    _attr_supported_features = WaterHeaterEntityFeature.OPERATION_MODE
 
     def __init__(self, coordinator: KospelDataUpdateCoordinator) -> None:
         """Initialize the water heater entity."""
@@ -112,18 +116,11 @@ class KospelWaterHeaterEntity(
         """Return if entity is available."""
         return self.coordinator.last_update_success
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
-        """Set new target temperature using mode-appropriate helper."""
-        controller = self._get_controller()
-        temperature = kwargs.get("temperature")
-        if temperature is not None:
-            operation = self.current_operation
-            if operation == STATE_PERFORMANCE:
-                await controller.set_water_comfort_temperature(temperature)
-            else:
-                await controller.set_water_economy_temperature(temperature)
-            self.async_write_ha_state()
-            await self.coordinator.async_request_refresh()
+    def _get_refresh_delay(self) -> float:
+        """Delay before refresh after set (from options or default)."""
+        return self.coordinator.entry.options.get(
+            CONF_REFRESH_DELAY_AFTER_SET, DEFAULT_REFRESH_DELAY_AFTER_SET
+        )
 
     async def async_set_operation_mode(self, operation_mode: str) -> None:
         """Set new operation mode via set_water_mode."""
@@ -134,23 +131,8 @@ class KospelWaterHeaterEntity(
                 controller = self._get_controller()
                 await controller.set_water_mode(cwu_mode)
                 self.async_write_ha_state()
+                await asyncio.sleep(self._get_refresh_delay())
                 await self.coordinator.async_request_refresh()
-
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn water heater on."""
-        controller = self._get_controller()
-        controller.is_water_heater_enabled = WaterHeaterEnabled.ENABLED
-        await controller.save()
-        self.async_write_ha_state()
-        await self.coordinator.async_request_refresh()
-
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn water heater off."""
-        controller = self._get_controller()
-        controller.is_water_heater_enabled = WaterHeaterEnabled.DISABLED
-        await controller.save()
-        self.async_write_ha_state()
-        await self.coordinator.async_request_refresh()
 
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""

--- a/tests/test_climate_entity.py
+++ b/tests/test_climate_entity.py
@@ -72,6 +72,8 @@ climate_mock = MagicMock()
 climate_mock.ClimateEntity = _ClimateEntityBase
 climate_mock.ClimateEntityFeature = _ClimateEntityFeature
 climate_mock.HVACMode = MagicMock()
+climate_mock.HVACMode.HEAT = "heat"
+climate_mock.HVACMode.OFF = "off"
 climate_mock.HVACAction = MagicMock()
 sys.modules["homeassistant.components.climate"] = climate_mock
 
@@ -80,6 +82,7 @@ from custom_components.kospel.climate import KospelClimateEntity
 
 ClimateEntityFeature = _ClimateEntityFeature
 HVACAction = climate_mock.HVACAction
+HVACMode = climate_mock.HVACMode
 
 
 @pytest.fixture
@@ -218,3 +221,25 @@ class TestClimateHvacAction:
         mock_coordinator.data = mock_controller
 
         assert climate_entity.hvac_action == HVACAction.OFF
+
+
+class TestClimateTurnOnOff:
+    """Tests for async_turn_on and async_turn_off (delegate to async_set_hvac_mode)."""
+
+    @pytest.mark.asyncio
+    async def test_turn_on_calls_set_hvac_mode_heat(
+        self, climate_entity, mock_coordinator
+    ) -> None:
+        """async_turn_on delegates to async_set_hvac_mode(HVACMode.HEAT)."""
+        climate_entity.async_set_hvac_mode = AsyncMock()
+        await climate_entity.async_turn_on()
+        climate_entity.async_set_hvac_mode.assert_called_once_with(HVACMode.HEAT)
+
+    @pytest.mark.asyncio
+    async def test_turn_off_calls_set_hvac_mode_off(
+        self, climate_entity, mock_coordinator
+    ) -> None:
+        """async_turn_off delegates to async_set_hvac_mode(HVACMode.OFF)."""
+        climate_entity.async_set_hvac_mode = AsyncMock()
+        await climate_entity.async_turn_off()
+        climate_entity.async_set_hvac_mode.assert_called_once_with(HVACMode.OFF)

--- a/tests/test_climate_entity.py
+++ b/tests/test_climate_entity.py
@@ -1,7 +1,7 @@
 """Tests for Kospel climate entity (target_temperature, supported_features, async_set_temperature)."""
 
 import sys
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -88,6 +88,7 @@ def mock_coordinator():
     coordinator = MagicMock()
     coordinator.entry = MagicMock()
     coordinator.entry.data = {}
+    coordinator.entry.options = {}
     coordinator.entry.entry_id = "test-entry-id"
     coordinator.last_update_success = True
     return coordinator
@@ -169,7 +170,8 @@ class TestClimateSetTemperature:
         mock_coordinator.data = mock_controller
         climate_entity.async_write_ha_state = MagicMock()
 
-        await climate_entity.async_set_temperature(temperature=25.0)
+        with patch("custom_components.kospel.climate.asyncio.sleep", new_callable=AsyncMock):
+            await climate_entity.async_set_temperature(temperature=25.0)
 
         mock_controller.set_manual_heating.assert_called_once_with(25.0)
         mock_coordinator.async_request_refresh.assert_called_once()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -9,6 +9,7 @@ import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import voluptuous as vol
 
 # Mock homeassistant before importing integration modules.
 # homeassistant must be a module (have __path__) for "from homeassistant.x import y" to work.
@@ -20,7 +21,35 @@ class _HAModule:
 
 _ha = _HAModule()
 sys.modules["homeassistant"] = _ha
-sys.modules["homeassistant.config_entries"] = MagicMock()
+
+
+class _ConfigFlowBase:
+    """Minimal ConfigFlow stand-in (required by KospelConfigFlowHandler)."""
+
+    @classmethod
+    def __init_subclass__(cls, **kwargs):
+        """Accept domain= and other kwargs from HA ConfigFlow pattern."""
+        super().__init_subclass__()
+
+
+class _OptionsFlowWithConfigEntryBase:
+    """Minimal OptionsFlowWithConfigEntry stand-in for options flow tests."""
+
+    def __init__(self, config_entry):
+        self.config_entry = config_entry
+        self.options = config_entry.options if config_entry.options is not None else {}
+
+    def async_create_entry(self, title, data):
+        return {"type": "create_entry", "data": data}
+
+    def async_show_form(self, step_id, data_schema):
+        return {"type": "show_form", "step_id": step_id, "data_schema": data_schema}
+
+
+_config_entries_mock = MagicMock()
+_config_entries_mock.ConfigFlow = _ConfigFlowBase
+_config_entries_mock.OptionsFlowWithConfigEntry = _OptionsFlowWithConfigEntryBase
+sys.modules["homeassistant.config_entries"] = _config_entries_mock
 sys.modules["homeassistant.components"] = MagicMock()
 sys.modules["homeassistant.components.network"] = MagicMock()
 sys.modules["homeassistant.components.climate"] = MagicMock()
@@ -44,14 +73,20 @@ sys.modules["homeassistant.helpers.entity"].DeviceInfo = _device_info
 
 from custom_components.kospel.const import (
     CONF_DEVICE_ID,
+    CONF_REFRESH_DELAY_AFTER_SET,
     CONF_SERIAL_NUMBER,
+    DEFAULT_REFRESH_DELAY_AFTER_SET,
     DEFAULT_SUBNETS,
+    REFRESH_DELAY_MAX,
+    REFRESH_DELAY_MIN,
     make_unique_id,
     get_device_identifier,
     get_device_info,
 )
 from custom_components.kospel.config_flow import (
     CannotConnect,
+    KospelConfigFlowHandler,
+    KospelOptionsFlowHandler,
     validate_http_input,
     _get_subnets_to_scan,
 )
@@ -234,3 +269,72 @@ class TestGetSubnetsToScan:
         ):
             result = await _get_subnets_to_scan(hass)
         assert result == DEFAULT_SUBNETS
+
+
+class TestKospelOptionsFlowHandler:
+    """Tests for KospelOptionsFlowHandler (options flow for refresh delay)."""
+
+    @pytest.mark.asyncio
+    async def test_init_form_shows_default_delay(self) -> None:
+        """async_step_init with no user_input shows form with default delay."""
+        config_entry = MagicMock()
+        config_entry.options = {}
+        handler = KospelOptionsFlowHandler(config_entry)
+
+        result = await handler.async_step_init(user_input=None)
+
+        assert result["type"] == "show_form"
+        assert result["step_id"] == "init"
+        assert CONF_REFRESH_DELAY_AFTER_SET in result["data_schema"].schema
+        # Default when options empty is DEFAULT_REFRESH_DELAY_AFTER_SET
+        assert handler.options.get(CONF_REFRESH_DELAY_AFTER_SET) is None
+
+    @pytest.mark.asyncio
+    async def test_init_form_saves_user_input(self) -> None:
+        """async_step_init with user_input saves and returns create_entry."""
+        config_entry = MagicMock()
+        config_entry.options = {}
+        handler = KospelOptionsFlowHandler(config_entry)
+        user_input = {CONF_REFRESH_DELAY_AFTER_SET: 2.0}
+
+        result = await handler.async_step_init(user_input=user_input)
+
+        assert result["type"] == "create_entry"
+        assert result["data"] == user_input
+
+    @pytest.mark.asyncio
+    async def test_init_form_uses_existing_option_as_default(self) -> None:
+        """async_step_init shows form when existing options present."""
+        config_entry = MagicMock()
+        config_entry.options = {CONF_REFRESH_DELAY_AFTER_SET: 2.5}
+        handler = KospelOptionsFlowHandler(config_entry)
+
+        result = await handler.async_step_init(user_input=None)
+
+        assert result["type"] == "show_form"
+        assert result["step_id"] == "init"
+        assert handler.options.get(CONF_REFRESH_DELAY_AFTER_SET) == 2.5
+
+    @pytest.mark.asyncio
+    async def test_async_get_options_flow_returns_handler(self) -> None:
+        """async_get_options_flow returns KospelOptionsFlowHandler instance."""
+        config_entry = MagicMock()
+        result = await KospelConfigFlowHandler.async_get_options_flow(config_entry)
+        assert isinstance(result, KospelOptionsFlowHandler)
+        assert result.config_entry is config_entry
+
+    def test_validation_rejects_out_of_range(self) -> None:
+        """vol.Range rejects values outside 0.5 to 5.0."""
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_REFRESH_DELAY_AFTER_SET): vol.All(
+                    vol.Coerce(float),
+                    vol.Range(min=REFRESH_DELAY_MIN, max=REFRESH_DELAY_MAX),
+                ),
+            }
+        )
+        schema({CONF_REFRESH_DELAY_AFTER_SET: 2.0})  # Valid
+        with pytest.raises(vol.Invalid):
+            schema({CONF_REFRESH_DELAY_AFTER_SET: 0.1})
+        with pytest.raises(vol.Invalid):
+            schema({CONF_REFRESH_DELAY_AFTER_SET: 10.0})

--- a/tests/test_water_heater_entity.py
+++ b/tests/test_water_heater_entity.py
@@ -1,7 +1,7 @@
-"""Tests for Kospel water heater entity (target_temperature, cwu_mode, set_operation_mode)."""
+"""Tests for Kospel water heater entity (target_temperature, current_operation)."""
 
 import sys
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -181,46 +181,3 @@ class TestWaterHeaterCurrentOperation:
         mock_coordinator.data = mock_controller
 
         assert water_heater_entity.current_operation == STATE_PERFORMANCE
-
-
-class TestWaterHeaterSetOperationMode:
-    """Tests for async_set_operation_mode (calls set_water_mode)."""
-
-    @pytest.mark.asyncio
-    async def test_set_operation_mode_calls_set_water_mode(
-        self, water_heater_entity, mock_coordinator
-    ) -> None:
-        """async_set_operation_mode calls set_water_mode with correct CwuMode."""
-        mock_controller = MagicMock()
-        mock_controller.is_water_heater_enabled = MagicMock()
-        mock_controller.set_water_mode = AsyncMock(return_value=True)
-        mock_coordinator.data = mock_controller
-        mock_coordinator.async_request_refresh = AsyncMock()
-        water_heater_entity.async_write_ha_state = MagicMock()
-
-        with patch(
-            "custom_components.kospel.water_heater.asyncio.sleep",
-            new_callable=AsyncMock,
-        ):
-            await water_heater_entity.async_set_operation_mode(STATE_ECO)
-
-        mock_controller.set_water_mode.assert_called_once_with(CwuMode.ECONOMY)
-
-    @pytest.mark.asyncio
-    async def test_set_operation_mode_comfort_calls_set_water_mode(
-        self, water_heater_entity, mock_coordinator
-    ) -> None:
-        """async_set_operation_mode(performance) calls set_water_mode(COMFORT)."""
-        mock_controller = MagicMock()
-        mock_controller.set_water_mode = AsyncMock(return_value=True)
-        mock_coordinator.data = mock_controller
-        mock_coordinator.async_request_refresh = AsyncMock()
-        water_heater_entity.async_write_ha_state = MagicMock()
-
-        with patch(
-            "custom_components.kospel.water_heater.asyncio.sleep",
-            new_callable=AsyncMock,
-        ):
-            await water_heater_entity.async_set_operation_mode(STATE_PERFORMANCE)
-
-        mock_controller.set_water_mode.assert_called_once_with(CwuMode.COMFORT)

--- a/tests/test_water_heater_entity.py
+++ b/tests/test_water_heater_entity.py
@@ -1,11 +1,12 @@
-"""Tests for Kospel water heater entity (target_temperature, cwu_mode, set_water_*)."""
+"""Tests for Kospel water heater entity (target_temperature, cwu_mode, set_operation_mode)."""
 
 import sys
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from kospel_cmi.registers.enums import CwuMode
+
 
 # Mock homeassistant before importing integration modules.
 class _HAModule:
@@ -38,6 +39,7 @@ def _device_info(**kwargs):
 
 sys.modules["homeassistant.helpers.entity"].DeviceInfo = _device_info
 
+
 # Create minimal base classes to avoid metaclass conflicts
 class _CoordinatorEntityBase:
     """Minimal CoordinatorEntity stand-in for testing."""
@@ -56,12 +58,12 @@ class _WaterHeaterEntityBase:
     pass
 
 
-sys.modules["homeassistant.helpers.update_coordinator"].CoordinatorEntity = (
-    _CoordinatorEntityBase
-)
-sys.modules["homeassistant.components.water_heater"].WaterHeaterEntity = (
-    _WaterHeaterEntityBase
-)
+sys.modules[
+    "homeassistant.helpers.update_coordinator"
+].CoordinatorEntity = _CoordinatorEntityBase
+sys.modules[
+    "homeassistant.components.water_heater"
+].WaterHeaterEntity = _WaterHeaterEntityBase
 
 from custom_components.kospel.water_heater import (
     KospelWaterHeaterEntity,
@@ -77,6 +79,7 @@ def mock_coordinator():
     coordinator = MagicMock()
     coordinator.entry = MagicMock()
     coordinator.entry.data = {}
+    coordinator.entry.options = {}
     coordinator.entry.entry_id = "test-entry-id"
     coordinator.last_update_success = True
     return coordinator
@@ -195,7 +198,11 @@ class TestWaterHeaterSetOperationMode:
         mock_coordinator.async_request_refresh = AsyncMock()
         water_heater_entity.async_write_ha_state = MagicMock()
 
-        await water_heater_entity.async_set_operation_mode(STATE_ECO)
+        with patch(
+            "custom_components.kospel.water_heater.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await water_heater_entity.async_set_operation_mode(STATE_ECO)
 
         mock_controller.set_water_mode.assert_called_once_with(CwuMode.ECONOMY)
 
@@ -210,52 +217,10 @@ class TestWaterHeaterSetOperationMode:
         mock_coordinator.async_request_refresh = AsyncMock()
         water_heater_entity.async_write_ha_state = MagicMock()
 
-        await water_heater_entity.async_set_operation_mode(STATE_PERFORMANCE)
+        with patch(
+            "custom_components.kospel.water_heater.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await water_heater_entity.async_set_operation_mode(STATE_PERFORMANCE)
 
         mock_controller.set_water_mode.assert_called_once_with(CwuMode.COMFORT)
-
-
-class TestWaterHeaterSetTemperature:
-    """Tests for async_set_temperature (calls set_water_*_temperature)."""
-
-    @pytest.mark.asyncio
-    async def test_set_temperature_economy_calls_set_water_economy_temperature(
-        self, water_heater_entity, mock_coordinator
-    ) -> None:
-        """async_set_temperature calls set_water_economy_temperature when in eco mode."""
-        from kospel_cmi.registers.enums import WaterHeaterEnabled
-
-        mock_controller = MagicMock()
-        mock_controller.is_water_heater_enabled = WaterHeaterEnabled.ENABLED
-        mock_controller.cwu_mode = CwuMode.ECONOMY
-        mock_controller.set_water_economy_temperature = AsyncMock(return_value=True)
-        mock_controller.set_water_comfort_temperature = AsyncMock(return_value=True)
-        mock_coordinator.data = mock_controller
-        mock_coordinator.async_request_refresh = AsyncMock()
-        water_heater_entity.async_write_ha_state = MagicMock()
-
-        await water_heater_entity.async_set_temperature(temperature=38.0)
-
-        mock_controller.set_water_economy_temperature.assert_called_once_with(38.0)
-        mock_controller.set_water_comfort_temperature.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_set_temperature_comfort_calls_set_water_comfort_temperature(
-        self, water_heater_entity, mock_coordinator
-    ) -> None:
-        """async_set_temperature calls set_water_comfort_temperature when in performance mode."""
-        from kospel_cmi.registers.enums import WaterHeaterEnabled
-
-        mock_controller = MagicMock()
-        mock_controller.is_water_heater_enabled = WaterHeaterEnabled.ENABLED
-        mock_controller.cwu_mode = CwuMode.COMFORT
-        mock_controller.set_water_economy_temperature = AsyncMock(return_value=True)
-        mock_controller.set_water_comfort_temperature = AsyncMock(return_value=True)
-        mock_coordinator.data = mock_controller
-        mock_coordinator.async_request_refresh = AsyncMock()
-        water_heater_entity.async_write_ha_state = MagicMock()
-
-        await water_heater_entity.async_set_temperature(temperature=45.0)
-
-        mock_controller.set_water_comfort_temperature.assert_called_once_with(45.0)
-        mock_controller.set_water_economy_temperature.assert_not_called()


### PR DESCRIPTION
## Summary

This PR addresses the UI reverting to previous values after mode changes and simplifies the water heater entity by making it read-only.

## Changes

### 1. Configurable refresh delay after set operations

Kospel devices can need a short delay to persist changes before a refresh. If the coordinator refreshes too soon, the UI may show the old value again.

- **New option**: `refresh_delay_after_set` (0.5–5.0 seconds, default 1.0)
- **Options flow**: Integration options (Configure) allow users to adjust the delay
- **Usage**: Applied in climate entity after `async_set_hvac_mode`, `async_set_temperature`, and `async_set_preset_mode` before `async_request_refresh`

### 2. Water heater entity simplified to read-only

The water heater entity is now read-only and only displays CWU state.

- **Removed**: `async_set_temperature`, `async_set_operation_mode`, and on/off control
- **Reason**: Climate entity controls main power; CWU mode and temperature are not configurable via this integration
- **Behavior**: Still shows current temperature, target temperature, and operation mode (eco/performance/off)

### 3. Climate entity improvements

- Added `async_turn_on` and `async_turn_off` delegating to `async_set_hvac_mode`
- Refresh delay applied consistently after all set operations

## Testing

- All 63 tests pass
- New tests for `KospelOptionsFlowHandler` (options flow)
- Removed tests for water heater set operations (no longer supported)