### PR TITLE
Feature/ekco m3 lib a12

### DIFF
--- a/custom_components/kospel/__init__.py
+++ b/custom_components/kospel/__init__.py
@@ -20,8 +20,7 @@ from .const import (
     get_yaml_state_file_path,
 )
 from .coordinator import KospelDataUpdateCoordinator
-from kospel_cmi.controller.api import HeaterController
-from kospel_cmi.controller.registry import load_registry
+from kospel_cmi.controller.device import Ekco_M3
 from kospel_cmi.kospel.backend import HttpRegisterBackend, YamlRegisterBackend
 
 _LOGGER = logging.getLogger(__name__)
@@ -59,8 +58,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         backend = HttpRegisterBackend(session, api_base_url)
 
     try:
-        registry = load_registry("kospel_cmi_standard")
-        heater_controller = HeaterController(backend=backend, registry=registry)
+        heater_controller = Ekco_M3(backend=backend)
         coordinator = KospelDataUpdateCoordinator(hass, entry, heater_controller)
         hass.data[DOMAIN][entry.entry_id] = coordinator
         await coordinator.async_config_entry_first_refresh()

--- a/custom_components/kospel/climate.py
+++ b/custom_components/kospel/climate.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import Any
+from typing import TypedDict, Unpack
 
 from homeassistant.components.climate import (
     ClimateEntity,
@@ -28,6 +28,12 @@ from kospel_cmi.registers.enums import HeaterMode, HeatingStatus
 from kospel_cmi.controller.device import Ekco_M3
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class _ClimateSetTemperatureKwargs(TypedDict, total=False):
+    """Keyword arguments Home Assistant may pass to async_set_temperature."""
+
+    temperature: float
 
 
 async def async_setup_entry(
@@ -74,13 +80,8 @@ class KospelClimateEntity(
         return controller.room_temperature
 
     @property
-    def _is_manual_mode(self) -> bool:
-        """Return True if manual mode is enabled."""
-        return self._heater_mode == HeaterMode.MANUAL
-
-    @property
     def supported_features(self) -> int:
-        """Return supported features; target temperature always shown, but only settable in manual mode."""
+        """Return supported features; target temperature is shown and sets manual heating when changed."""
         return (
             ClimateEntityFeature.PRESET_MODE
             | ClimateEntityFeature.TURN_ON
@@ -103,7 +104,7 @@ class KospelClimateEntity(
     def hvac_action(self) -> HVACAction:
         """HVAC action is based on whether CO heating circuit is active."""
         controller: Ekco_M3 = self.coordinator.data
-        co_status = getattr(controller, "co_heating_status", HeatingStatus.IDLE)
+        co_status = controller.co_heating_status
         return (
             HVACAction.HEATING
             if co_status == HeatingStatus.RUNNING
@@ -139,11 +140,8 @@ class KospelClimateEntity(
         await asyncio.sleep(get_refresh_delay_after_set(self.coordinator.entry))
         await self.coordinator.async_request_refresh()
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
-        """Set new target temperature (only when manual mode is on)."""
-        if not self._is_manual_mode:
-            _LOGGER.debug("Ignoring set_temperature: manual mode is off")
-            return
+    async def async_set_temperature(self, **kwargs: Unpack[_ClimateSetTemperatureKwargs]) -> None:
+        """Set manual heating target; device switches to MANUAL mode (see Ekco_M3.set_manual_heating)."""
         controller: Ekco_M3 = self.coordinator.data
         temperature = kwargs.get("temperature")
         if temperature is not None:

--- a/custom_components/kospel/climate.py
+++ b/custom_components/kospel/climate.py
@@ -25,7 +25,7 @@ from .const import (
 from .coordinator import KospelDataUpdateCoordinator
 
 from kospel_cmi.registers.enums import HeaterMode, HeatingStatus
-from kospel_cmi.controller.api import HeaterController
+from kospel_cmi.controller.device import Ekco_M3
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -64,15 +64,14 @@ class KospelClimateEntity(
     @property
     def _heater_mode(self) -> HeaterMode:
         """Current heater mode from the controller."""
-        controller: HeaterController = self.coordinator.data
-        return getattr(controller, "heater_mode", HeaterMode.OFF)
+        controller: Ekco_M3 = self.coordinator.data
+        return controller.heater_mode or HeaterMode.OFF
 
     @property
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
-        controller: HeaterController = self.coordinator.data
-        # Use room temperature sensor (register 0b6d) as current temperature
-        return getattr(controller, "room_temperature", None)
+        controller: Ekco_M3 = self.coordinator.data
+        return controller.room_temperature
 
     @property
     def _is_manual_mode(self) -> bool:
@@ -92,8 +91,8 @@ class KospelClimateEntity(
     @property
     def target_temperature(self) -> float | None:
         """Return the target temperature (always room_setpoint)."""
-        controller: HeaterController = self.coordinator.data
-        return getattr(controller, "room_setpoint", None)
+        controller: Ekco_M3 = self.coordinator.data
+        return controller.room_setpoint
 
     @property
     def hvac_mode(self) -> HVACMode:
@@ -103,11 +102,11 @@ class KospelClimateEntity(
     @property
     def hvac_action(self) -> HVACAction:
         """HVAC action is based on whether CO heating circuit is active."""
-        controller: HeaterController = self.coordinator.data
+        controller: Ekco_M3 = self.coordinator.data
+        co_status = getattr(controller, "co_heating_status", HeatingStatus.IDLE)
         return (
             HVACAction.HEATING
-            if getattr(controller, "co_heating_status", HeatingStatus.IDLE)
-            == HeatingStatus.RUNNING
+            if co_status == HeatingStatus.RUNNING
             else HVACAction.OFF
         )
 
@@ -132,12 +131,10 @@ class KospelClimateEntity(
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target HVAC mode."""
         _LOGGER.debug("Setting HVAC mode to %s", hvac_mode)
-        controller: HeaterController = self.coordinator.data
+        controller: Ekco_M3 = self.coordinator.data
 
-        controller.heater_mode = (
-            HeaterMode.OFF if hvac_mode == HVACMode.OFF else HeaterMode.WINTER
-        )
-        await controller.save()
+        mode = HeaterMode.OFF if hvac_mode == HVACMode.OFF else HeaterMode.WINTER
+        await controller.set_heater_mode(mode)
         self.async_write_ha_state()
         await asyncio.sleep(get_refresh_delay_after_set(self.coordinator.entry))
         await self.coordinator.async_request_refresh()
@@ -147,7 +144,7 @@ class KospelClimateEntity(
         if not self._is_manual_mode:
             _LOGGER.debug("Ignoring set_temperature: manual mode is off")
             return
-        controller: HeaterController = self.coordinator.data
+        controller: Ekco_M3 = self.coordinator.data
         temperature = kwargs.get("temperature")
         if temperature is not None:
             await controller.set_manual_heating(temperature)
@@ -158,9 +155,8 @@ class KospelClimateEntity(
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         _LOGGER.debug("Setting preset mode to %s", preset_mode)
-        controller: HeaterController = self.coordinator.data
-        controller.heater_mode = HeaterMode(preset_mode.lower())
-        await controller.save()
+        controller: Ekco_M3 = self.coordinator.data
+        await controller.set_heater_mode(HeaterMode(preset_mode.lower()))
         self.async_write_ha_state()
         await asyncio.sleep(get_refresh_delay_after_set(self.coordinator.entry))
         await self.coordinator.async_request_refresh()

--- a/custom_components/kospel/coordinator.py
+++ b/custom_components/kospel/coordinator.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from kospel_cmi.controller.api import HeaterController
+from kospel_cmi.controller.device import Ekco_M3
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -13,21 +13,21 @@ from .const import DOMAIN, SCAN_INTERVAL
 _LOGGER = logging.getLogger(__name__)
 
 
-class KospelDataUpdateCoordinator(DataUpdateCoordinator[HeaterController]):
+class KospelDataUpdateCoordinator(DataUpdateCoordinator[Ekco_M3]):
     """Class to manage fetching data from the Kospel heater."""
 
     def __init__(
         self,
         hass: HomeAssistant,
         entry: ConfigEntry,
-        heater_controller: HeaterController,
+        heater_controller: Ekco_M3,
     ) -> None:
         """Initialize the coordinator.
 
         Args:
             hass: Home Assistant instance.
             entry: Config entry for this integration.
-            heater_controller: HeaterController (backed by HTTP or YAML backend).
+            heater_controller: Ekco_M3 device (backed by HTTP or YAML backend).
         """
         super().__init__(
             hass,
@@ -39,11 +39,11 @@ class KospelDataUpdateCoordinator(DataUpdateCoordinator[HeaterController]):
         self.entry = entry
         self.heater_controller = heater_controller
 
-    async def _async_update_data(self) -> HeaterController:
+    async def _async_update_data(self) -> Ekco_M3:
         """Fetch data from the heater controller.
 
         Returns:
-            HeaterController instance (entities access settings via coordinator.data).
+            Ekco_M3 instance (entities access settings via coordinator.data).
         """
         try:
             await self.heater_controller.refresh()

--- a/custom_components/kospel/manifest.json
+++ b/custom_components/kospel/manifest.json
@@ -8,7 +8,7 @@
   "dependencies": ["http", "network"],
   "requirements": [
     "aiohttp>=3.13.3",
-    "kospel-cmi-lib==0.1.0a11"
+    "kospel-cmi-lib==0.1.0a12"
   ],
   "codeowners": ["@JanKrl"],
   "integration_type": "hub",

--- a/custom_components/kospel/sensor.py
+++ b/custom_components/kospel/sensor.py
@@ -1,5 +1,7 @@
 """Sensor entities for Kospel integration."""
 
+from collections.abc import Callable
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -103,17 +105,17 @@ class KospelTemperatureSensor(KospelSensorEntity):
         coordinator: KospelDataUpdateCoordinator,
         entry: ConfigEntry,
         unique_id_suffix: str,
-        setting_name: str,
+        value_getter: Callable[[Ekco_M3], float | None],
     ) -> None:
         """Initialize the temperature sensor."""
         super().__init__(coordinator, entry, unique_id_suffix, unique_id_suffix)
-        self._setting_name = setting_name
+        self._value_getter = value_getter
 
     @property
     def native_value(self) -> float | None:
         """Return the temperature value."""
         controller: Ekco_M3 = self.coordinator.data
-        return getattr(controller, self._setting_name, None)
+        return self._value_getter(controller)
 
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""

--- a/custom_components/kospel/sensor.py
+++ b/custom_components/kospel/sensor.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN, get_device_info, get_device_identifier
 from .coordinator import KospelDataUpdateCoordinator
 
-from kospel_cmi.controller.api import HeaterController
+from kospel_cmi.controller.device import Ekco_M3
 
 
 async def async_setup_entry(
@@ -112,7 +112,7 @@ class KospelTemperatureSensor(KospelSensorEntity):
     @property
     def native_value(self) -> float | None:
         """Return the temperature value."""
-        controller: HeaterController = self.coordinator.data
+        controller: Ekco_M3 = self.coordinator.data
         return getattr(controller, self._setting_name, None)
 
     def _handle_coordinator_update(self) -> None:
@@ -138,8 +138,8 @@ class KospelPressureSensor(KospelSensorEntity):
     @property
     def native_value(self) -> float | None:
         """Return the pressure value."""
-        controller: HeaterController = self.coordinator.data
-        return getattr(controller, "pressure", None)
+        controller: Ekco_M3 = self.coordinator.data
+        return controller.pressure
 
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
@@ -147,10 +147,14 @@ class KospelPressureSensor(KospelSensorEntity):
 
 
 class KospelPowerSensor(KospelSensorEntity):
-    """Representation of a Kospel power sensor (heating element power in kW)."""
+    """Representation of instantaneous power in watts.
+
+    The library reports power in kW; this sensor exposes native W for the
+    Energy dashboard and long-term statistics.
+    """
 
     _attr_device_class = SensorDeviceClass.POWER
-    _attr_native_unit_of_measurement = UnitOfPower.KILO_WATT
+    _attr_native_unit_of_measurement = UnitOfPower.WATT
     _attr_state_class = SensorStateClass.MEASUREMENT
 
     def __init__(
@@ -163,9 +167,12 @@ class KospelPowerSensor(KospelSensorEntity):
 
     @property
     def native_value(self) -> float | None:
-        """Return the power value in kW."""
-        controller: HeaterController = self.coordinator.data
-        return getattr(controller, "power", None)
+        """Return the power value in W (device reports kW)."""
+        controller: Ekco_M3 = self.coordinator.data
+        power_kw = controller.power
+        if power_kw is None:
+            return None
+        return power_kw * 1000.0
 
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
@@ -189,7 +196,7 @@ class KospelHeatingStatusSensor(KospelSensorEntity):
     @property
     def native_value(self) -> str | None:
         """Return the heating status (RUNNING, IDLE, DISABLED)."""
-        controller: HeaterController = self.coordinator.data
+        controller: Ekco_M3 = self.coordinator.data
         status = getattr(controller, self._setting_name, None)
         if status is None:
             return None
@@ -216,8 +223,8 @@ class KospelValvePositionSensor(KospelSensorEntity):
     @property
     def native_value(self) -> str | None:
         """Return the valve position."""
-        controller: HeaterController = self.coordinator.data
-        position = getattr(controller, "valve_position", None)
+        controller: Ekco_M3 = self.coordinator.data
+        position = controller.valve_position
         if position is None:
             return None
         if hasattr(position, "value"):

--- a/custom_components/kospel/water_heater.py
+++ b/custom_components/kospel/water_heater.py
@@ -1,8 +1,9 @@
 """Water heater entity for Kospel integration (CWU / DHW)."""
 
 import logging
+from typing import Any
 
-from homeassistant.components.water_heater import WaterHeaterEntity
+from homeassistant.components.water_heater import WaterHeaterEntity, WaterHeaterEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
@@ -13,7 +14,7 @@ from .const import DOMAIN, get_device_info, get_device_identifier
 from .coordinator import KospelDataUpdateCoordinator
 
 from kospel_cmi.registers.enums import CwuMode, WaterHeaterEnabled
-from kospel_cmi.controller.api import HeaterController
+from kospel_cmi.controller.device import Ekco_M3
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -58,7 +59,9 @@ class KospelWaterHeaterEntity(
     _attr_operation_list = OPERATION_LIST
     _attr_min_temp = 30.0
     _attr_max_temp = 65.0
-    _attr_supported_features = 0  # Read-only: no set operations
+    _attr_supported_features = (
+        WaterHeaterEntityFeature.OPERATION_MODE | WaterHeaterEntityFeature.TARGET_TEMPERATURE
+    )
 
     def __init__(self, coordinator: KospelDataUpdateCoordinator) -> None:
         """Initialize the water heater entity."""
@@ -67,15 +70,23 @@ class KospelWaterHeaterEntity(
         self._attr_unique_id = f"{device_id}_water_heater"
         self._attr_device_info = get_device_info(coordinator.entry)
 
-    def _get_controller(self) -> HeaterController:
-        """Return the heater controller from coordinator data."""
+    def _get_controller(self) -> Ekco_M3:
+        """Return the device controller from coordinator data."""
         return self.coordinator.data
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Ignore temperature writes; DHW setpoints are changed on the device or via climate."""
+        _LOGGER.debug("Ignoring set_temperature on read-only DHW entity")
+
+    async def async_set_operation_mode(self, operation_mode: str) -> None:
+        """Ignore operation mode writes; CWU mode is not controlled here."""
+        _LOGGER.debug("Ignoring set_operation_mode on read-only DHW entity")
 
     @property
     def current_temperature(self) -> float | None:
         """Return the current water temperature."""
         controller = self._get_controller()
-        return getattr(controller, "water_current_temperature", None)
+        return controller.water_current_temperature
 
     @property
     def target_temperature(self) -> float | None:
@@ -92,10 +103,10 @@ class KospelWaterHeaterEntity(
     def current_operation(self) -> str:
         """Return the current operation mode from device cwu_mode."""
         controller = self._get_controller()
-        if getattr(controller, "is_water_heater_enabled", WaterHeaterEnabled.DISABLED) == WaterHeaterEnabled.DISABLED:
+        if getattr(controller, "is_water_heater_enabled", WaterHeaterEnabled.DISABLED) != WaterHeaterEnabled.ENABLED:
             return STATE_OFF
         cwu_mode = getattr(controller, "cwu_mode", 0)
-        return _CWU_MODE_TO_HA.get(cwu_mode, STATE_ECO)
+        return _CWU_MODE_TO_HA.get(cwu_mode or 0, STATE_ECO)
 
     @property
     def available(self) -> bool:

--- a/custom_components/kospel/water_heater.py
+++ b/custom_components/kospel/water_heater.py
@@ -1,7 +1,7 @@
 """Water heater entity for Kospel integration (CWU / DHW)."""
 
 import logging
-from typing import Any
+from typing import TypedDict, Unpack
 
 from homeassistant.components.water_heater import WaterHeaterEntity, WaterHeaterEntityFeature
 from homeassistant.config_entries import ConfigEntry
@@ -31,6 +31,13 @@ _CWU_MODE_TO_HA: dict[int, str] = {
     CwuMode.ANTI_FREEZE: STATE_OFF,
     CwuMode.COMFORT: STATE_PERFORMANCE,
 }
+
+
+class _WaterHeaterSetTemperatureKwargs(TypedDict, total=False):
+    """Keyword arguments Home Assistant may pass to async_set_temperature."""
+
+    temperature: float
+    operation_mode: str
 
 
 async def async_setup_entry(
@@ -74,13 +81,18 @@ class KospelWaterHeaterEntity(
         """Return the device controller from coordinator data."""
         return self.coordinator.data
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_temperature(
+        self, **kwargs: Unpack[_WaterHeaterSetTemperatureKwargs]
+    ) -> None:
         """Ignore temperature writes; DHW setpoints are changed on the device or via climate."""
         _LOGGER.debug("Ignoring set_temperature on read-only DHW entity")
 
     async def async_set_operation_mode(self, operation_mode: str) -> None:
         """Ignore operation mode writes; CWU mode is not controlled here."""
-        _LOGGER.debug("Ignoring set_operation_mode on read-only DHW entity")
+        _LOGGER.debug(
+            "Ignoring set_operation_mode on read-only DHW entity (mode=%s)",
+            operation_mode,
+        )
 
     @property
     def current_temperature(self) -> float | None:
@@ -92,20 +104,20 @@ class KospelWaterHeaterEntity(
     def target_temperature(self) -> float | None:
         """Return the target temperature from the active setpoint (mode-dependent)."""
         controller = self._get_controller()
-        cwu_mode = getattr(controller, "cwu_mode", 0)
+        cwu_mode = controller.cwu_mode
         if cwu_mode == CwuMode.COMFORT:
-            return getattr(controller, "cwu_temperature_comfort", None)
+            return controller.cwu_temperature_comfort
         if cwu_mode == CwuMode.ANTI_FREEZE:
-            return getattr(controller, "cwu_temperature_economy", None)
-        return getattr(controller, "cwu_temperature_economy", None)
+            return controller.cwu_temperature_economy
+        return controller.cwu_temperature_economy
 
     @property
     def current_operation(self) -> str:
         """Return the current operation mode from device cwu_mode."""
         controller = self._get_controller()
-        if getattr(controller, "is_water_heater_enabled", WaterHeaterEnabled.DISABLED) != WaterHeaterEnabled.ENABLED:
+        if controller.is_water_heater_enabled != WaterHeaterEnabled.ENABLED:
             return STATE_OFF
-        cwu_mode = getattr(controller, "cwu_mode", 0)
+        cwu_mode = controller.cwu_mode
         return _CWU_MODE_TO_HA.get(cwu_mode or 0, STATE_ECO)
 
     @property

--- a/custom_components/kospel/water_heater.py
+++ b/custom_components/kospel/water_heater.py
@@ -55,8 +55,10 @@ class KospelWaterHeaterEntity(
 ):
     """Representation of a Kospel domestic hot water (CWU/DHW) entity.
 
-    Read-only: displays current temperature, target temperature, and operation
-    mode. Climate entity controls main power; CWU mode is not configurable here.
+    Read-only for writes: displays current temperature, target temperature, and
+    operation mode. Target/operation controls on this entity are intentionally
+    no-ops; DHW/CWU setpoints and modes follow the heater presets and the
+    climate entity, not the water heater card.
     """
 
     _attr_has_entity_name = True
@@ -66,6 +68,9 @@ class KospelWaterHeaterEntity(
     _attr_operation_list = OPERATION_LIST
     _attr_min_temp = 30.0
     _attr_max_temp = 65.0
+    # OPERATION_MODE and TARGET_TEMPERATURE are declared so Home Assistant shows
+    # current operation and temperatures in the UI. Writes are ignored here by design:
+    # DHW/CWU behaviour is driven by the device and by climate presets (see async_set_*).
     _attr_supported_features = (
         WaterHeaterEntityFeature.OPERATION_MODE | WaterHeaterEntityFeature.TARGET_TEMPERATURE
     )

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,10 +14,8 @@ graph TB
     end
 
     subgraph Library["kospel-cmi-lib (external)"]
-        HeaterController[HeaterController]
+        Ekco_M3[Ekco_M3 device]
         Backend[Http or YAML backend]
-        Registry[load_registry configs/yaml]
-        API[api.py - read/write registers]
         Registers[registers - decoders encoders enums utils]
     end
 
@@ -26,17 +24,12 @@ graph TB
     end
 
     HA --> Coordinator
-    Coordinator --> HeaterController
-    ClimateEntity --> HeaterController
-    SensorEntity --> HeaterController
-    WaterHeaterEntity --> HeaterController
-    ConfigFlow --> HeaterController
+    Coordinator --> Ekco_M3
+    ClimateEntity --> Ekco_M3
+    SensorEntity --> Ekco_M3
+    WaterHeaterEntity --> Ekco_M3
 
-    HeaterController --> Backend
-    HeaterController --> Registry
-    Backend --> API
-    Registry --> Registers
-    API --> Registers
-
-    API --> HeaterAPI
+    Ekco_M3 --> Backend
+    Backend --> Registers
+    Backend --> HeaterAPI
 ```

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -20,14 +20,12 @@ The integration uses **kospel-cmi-lib** for heater communication. Imports use ab
 
 ```python
 # Correct: Absolute imports from kospel-cmi-lib (installed via manifest requirements)
-from kospel_cmi.controller.api import HeaterController
-from kospel_cmi.controller.registry import load_registry
+from kospel_cmi.controller.device import Ekco_M3
 from kospel_cmi.kospel.backend import HttpRegisterBackend, YamlRegisterBackend
 from kospel_cmi.registers.enums import HeaterMode
 
-# Registry: load by name, pass to HeaterController
-registry = load_registry("kospel_cmi_standard")
-controller = HeaterController(backend=..., registry=registry)
+# Device controller: backend only (register map is built into Ekco_M3)
+controller = Ekco_M3(backend=...)
 
 # Within integration: use relative imports
 from .const import DOMAIN

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license-files = ["LICENSE*"]
 requires-python = ">=3.11"
 dependencies = [
     "aiohttp>=3.13.3",
-    "kospel-cmi-lib==0.1.0a11",
+    "kospel-cmi-lib==0.1.0a12",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,8 +7,7 @@ from unittest.mock import AsyncMock
 
 import aiohttp
 
-from kospel_cmi.controller.api import HeaterController, SettingDefinition
-from kospel_cmi.controller.registry import load_registry
+from kospel_cmi.controller.device import Ekco_M3
 from kospel_cmi.kospel.backend import HttpRegisterBackend, YamlRegisterBackend
 
 
@@ -16,12 +15,6 @@ from kospel_cmi.kospel.backend import HttpRegisterBackend, YamlRegisterBackend
 def api_base_url() -> str:
     """Standard API base URL fixture."""
     return "http://192.168.1.100/api/dev/65"
-
-
-@pytest.fixture
-def registry() -> dict[str, SettingDefinition]:
-    """Settings registry from kospel_cmi_standard config."""
-    return load_registry("kospel_cmi_standard")
 
 
 @pytest.fixture
@@ -146,11 +139,11 @@ def yaml_backend_state_file(tmp_path: Path) -> Path:
 
 @pytest.fixture
 async def heater_controller(
-    mock_session: AsyncMock, api_base_url: str, registry: dict[str, SettingDefinition]
-) -> HeaterController:
-    """HeaterController instance fixture (HTTP backend)."""
+    mock_session: AsyncMock, api_base_url: str
+) -> Ekco_M3:
+    """Ekco_M3 instance fixture (HTTP backend)."""
     backend = HttpRegisterBackend(mock_session, api_base_url)
-    return HeaterController(backend=backend, registry=registry)
+    return Ekco_M3(backend=backend)
 
 
 @pytest.fixture
@@ -158,11 +151,10 @@ async def heater_controller_with_registers(
     mock_session: AsyncMock,
     api_base_url: str,
     sample_registers: Dict[str, str],
-    registry: dict[str, SettingDefinition],
-) -> HeaterController:
-    """HeaterController instance with pre-loaded register data."""
+) -> Ekco_M3:
+    """Ekco_M3 instance with pre-loaded register data."""
     backend = HttpRegisterBackend(mock_session, api_base_url)
-    controller = HeaterController(backend=backend, registry=registry)
+    controller = Ekco_M3(backend=backend)
     controller.from_registers(sample_registers)
     return controller
 
@@ -170,8 +162,7 @@ async def heater_controller_with_registers(
 @pytest.fixture
 async def heater_controller_yaml(
     yaml_backend_state_file: Path,
-    registry: dict[str, SettingDefinition],
-) -> HeaterController:
-    """HeaterController instance with YAML backend (for development/mock tests)."""
+) -> Ekco_M3:
+    """Ekco_M3 instance with YAML backend (for development/mock tests)."""
     backend = YamlRegisterBackend(state_file=str(yaml_backend_state_file))
-    return HeaterController(backend=backend, registry=registry)
+    return Ekco_M3(backend=backend)

--- a/tests/integration/test_api_communication.py
+++ b/tests/integration/test_api_communication.py
@@ -10,6 +10,12 @@ from kospel_cmi.kospel.backend import HttpRegisterBackend
 from kospel_cmi.registers.enums import HeaterMode
 
 
+def _get_request_count(m: object) -> int:
+    """Count mocked HTTP GET requests (aioresponses keys are (method, url) tuples)."""
+    requests = getattr(m, "requests", {})
+    return sum(1 for method, _ in requests if method == "GET")
+
+
 class TestEndToEndReadWrite:
     """Tests for full read/write cycle."""
 
@@ -37,7 +43,7 @@ class TestEndToEndReadWrite:
 
                 # Refresh from API
                 await controller.refresh()
-                assert len(controller._registers) > 0
+                assert controller.heater_mode is not None
 
                 # Modify setting via immediate write
                 result = await controller.set_heater_mode(HeaterMode.WINTER)
@@ -95,7 +101,7 @@ class TestBatchOperations:
 
                 await controller.refresh()
 
-                assert len(controller._registers) > 0
+                assert controller.heater_mode is not None
 
     @pytest.mark.asyncio
     async def test_set_heater_mode_writes_immediately(
@@ -164,6 +170,7 @@ class TestErrorRecovery:
 
                 await controller.refresh()
 
+                # Library exposes no public signal for empty batch; _registers is empty on API failure.
                 assert len(controller._registers) == 0
 
     @pytest.mark.asyncio
@@ -205,7 +212,7 @@ class TestErrorRecovery:
 
                 await controller.refresh()
 
-                assert controller.heater_mode is None or len(controller._registers) > 0
+                assert controller.heater_mode is None
 
     @pytest.mark.asyncio
     async def test_partial_write_failures(
@@ -280,12 +287,13 @@ class TestRegisterCaching:
                 controller = Ekco_M3(backend=backend)
 
                 await controller.refresh()
-                original_value = controller._registers.get("0b55")
+                original_mode = controller.heater_mode
 
                 await controller.refresh()
-                new_value = controller._registers.get("0b55")
+                new_mode = controller.heater_mode
 
-                assert original_value != new_value
+                assert original_mode != new_mode
+                assert new_mode == HeaterMode.WINTER
 
     @pytest.mark.asyncio
     async def test_cache_updated_after_successful_write(
@@ -309,4 +317,4 @@ class TestRegisterCaching:
                 result = await controller.set_heater_mode(HeaterMode.WINTER)
                 assert result is True
 
-                assert "0b55" in controller._registers
+                assert controller.heater_mode == HeaterMode.WINTER

--- a/tests/integration/test_api_communication.py
+++ b/tests/integration/test_api_communication.py
@@ -1,12 +1,11 @@
 """Integration tests for end-to-end API communication."""
 
 import pytest
-from unittest.mock import AsyncMock, patch
 from aioresponses import aioresponses
 
 import aiohttp
 
-from kospel_cmi.controller.api import HeaterController
+from kospel_cmi.controller.device import Ekco_M3
 from kospel_cmi.kospel.backend import HttpRegisterBackend
 from kospel_cmi.registers.enums import HeaterMode
 
@@ -16,7 +15,7 @@ class TestEndToEndReadWrite:
 
     @pytest.mark.asyncio
     async def test_end_to_end_read_write(
-        self, api_base_url, sample_registers, registry
+        self, api_base_url, sample_registers
     ):
         """Test full read/write cycle with mocked HTTP."""
         registers = sample_registers.copy()
@@ -26,27 +25,22 @@ class TestEndToEndReadWrite:
             read_url = f"{api_base_url}/0b00/256"
             m.get(read_url, payload={"regs": registers})
 
-            # Mock save (write register)
-            write_url = f"{api_base_url}/0b55"
-            m.post(write_url, payload={"status": "0"})
-            # Mock read for save (cache miss)
-            read_single_url = f"{api_base_url}/0b55/1"
-            m.get(read_single_url, payload={"regs": {"0b55": registers["0b55"]}})
+            # Mock set_heater_mode writes (0b55 and 0b32 for MANUAL, or just 0b55)
+            write_url_55 = f"{api_base_url}/0b55"
+            write_url_32 = f"{api_base_url}/0b32"
+            m.post(write_url_55, payload={"status": "0"})
+            m.post(write_url_32, payload={"status": "0"})
 
             async with aiohttp.ClientSession() as session:
                 backend = HttpRegisterBackend(session, api_base_url)
-                controller = HeaterController(backend=backend, registry=registry)
+                controller = Ekco_M3(backend=backend)
 
                 # Refresh from API
                 await controller.refresh()
-                assert len(controller._settings) > 0
+                assert len(controller._registers) > 0
 
-                # Modify setting
-                original_mode = controller.heater_mode
-                controller.heater_mode = HeaterMode.WINTER
-
-                # Save to API
-                result = await controller.save()
+                # Modify setting via immediate write
+                result = await controller.set_heater_mode(HeaterMode.WINTER)
                 assert result is True
 
                 # Verify changes are reflected
@@ -54,46 +48,38 @@ class TestEndToEndReadWrite:
 
     @pytest.mark.asyncio
     async def test_multiple_settings_change(
-        self, api_base_url, sample_registers, registry
+        self, api_base_url, sample_registers
     ):
-        """Test modifying multiple settings."""
+        """Test modifying multiple settings (each writes immediately)."""
         registers = sample_registers.copy()
 
         with aioresponses() as m:
-            # Mock refresh
             read_url = f"{api_base_url}/0b00/256"
             m.get(read_url, payload={"regs": registers})
 
-            # Mock save (both settings in same register 0b55)
-            write_url = f"{api_base_url}/0b55"
-            m.post(write_url, payload={"status": "0"})
-            # Mock read for save
-            read_single_url = f"{api_base_url}/0b55/1"
-            m.get(read_single_url, payload={"regs": {"0b55": registers["0b55"]}})
+            write_url_55 = f"{api_base_url}/0b55"
+            write_url_32 = f"{api_base_url}/0b32"
+            m.post(write_url_55, payload={"status": "0"})
+            m.post(write_url_32, payload={"status": "0"})
 
             async with aiohttp.ClientSession() as session:
                 backend = HttpRegisterBackend(session, api_base_url)
-                controller = HeaterController(backend=backend, registry=registry)
+                controller = Ekco_M3(backend=backend)
                 await controller.refresh()
 
-                # Modify multiple settings
-                controller.heater_mode = HeaterMode.MANUAL
-
-                # Save
-                result = await controller.save()
+                result = await controller.set_heater_mode(HeaterMode.MANUAL)
                 assert result is True
 
 
 class TestBatchOperations:
-    """Tests for batch read/write operations."""
+    """Tests for batch read operations."""
 
     @pytest.mark.asyncio
     async def test_single_refresh_reads_all_registers(
-        self, api_base_url, sample_registers, registry
+        self, api_base_url, sample_registers
     ):
         """Test that single refresh reads all registers."""
         registers = sample_registers.copy()
-        # Add more registers
         for i in range(256):
             reg_key = f"0b{i:02x}"
             if reg_key not in registers:
@@ -105,80 +91,60 @@ class TestBatchOperations:
 
             async with aiohttp.ClientSession() as session:
                 backend = HttpRegisterBackend(session, api_base_url)
-                controller = HeaterController(backend=backend, registry=registry)
+                controller = Ekco_M3(backend=backend)
 
-                # Single refresh call
                 await controller.refresh()
 
-                # Verify all settings were loaded
-                assert len(controller._settings) > 0
-                assert len(controller._register_cache) > 0
+                assert len(controller._registers) > 0
 
     @pytest.mark.asyncio
-    async def test_multiple_settings_batched_into_single_write(
-        self, api_base_url, sample_registers, registry
+    async def test_set_heater_mode_writes_immediately(
+        self, api_base_url, sample_registers
     ):
-        """Test that multiple setting changes are batched into single write."""
+        """Test that set_heater_mode writes immediately."""
         registers = sample_registers.copy()
 
         with aioresponses() as m:
-            # Mock refresh
             read_url = f"{api_base_url}/0b00/256"
             m.get(read_url, payload={"regs": registers})
 
-            # Mock save - should only write once per register
-            write_url = f"{api_base_url}/0b55"
-            m.post(write_url, payload={"status": "0"})
-            # Mock read for save
-            read_single_url = f"{api_base_url}/0b55/1"
-            m.get(read_single_url, payload={"regs": {"0b55": registers["0b55"]}})
+            write_url_55 = f"{api_base_url}/0b55"
+            write_url_32 = f"{api_base_url}/0b32"
+            m.post(write_url_55, payload={"status": "0"})
+            m.post(write_url_32, payload={"status": "0"})
 
             async with aiohttp.ClientSession() as session:
                 backend = HttpRegisterBackend(session, api_base_url)
-                controller = HeaterController(backend=backend, registry=registry)
+                controller = Ekco_M3(backend=backend)
                 await controller.refresh()
 
-                # Modify setting in register 0b55
-                controller.heater_mode = HeaterMode.MANUAL
-
-                # Save should write to register
-                result = await controller.save()
+                result = await controller.set_heater_mode(HeaterMode.MANUAL)
                 assert result is True
 
     @pytest.mark.asyncio
-    async def test_register_grouping_works(
-        self, api_base_url, sample_registers, registry
+    async def test_set_manual_heating_writes_both_registers(
+        self, api_base_url, sample_registers
     ):
-        """Test that register grouping works correctly."""
+        """Test that set_manual_heating writes 0b55, 0b32, 0b8d."""
         registers = sample_registers.copy()
 
         with aioresponses() as m:
-            # Mock refresh
             read_url = f"{api_base_url}/0b00/256"
             m.get(read_url, payload={"regs": registers})
 
-            # Mock multiple writes (different registers)
             write_url_55 = f"{api_base_url}/0b55"
+            write_url_32 = f"{api_base_url}/0b32"
             write_url_8d = f"{api_base_url}/0b8d"
             m.post(write_url_55, payload={"status": "0"})
+            m.post(write_url_32, payload={"status": "0"})
             m.post(write_url_8d, payload={"status": "0"})
-            # Mock reads for save
-            read_url_55 = f"{api_base_url}/0b55/1"
-            read_url_8d = f"{api_base_url}/0b8d/1"
-            m.get(read_url_55, payload={"regs": {"0b55": registers["0b55"]}})
-            m.get(read_url_8d, payload={"regs": {"0b8d": registers["0b8d"]}})
 
             async with aiohttp.ClientSession() as session:
                 backend = HttpRegisterBackend(session, api_base_url)
-                controller = HeaterController(backend=backend, registry=registry)
+                controller = Ekco_M3(backend=backend)
                 await controller.refresh()
 
-                # Modify settings in different registers
-                controller.heater_mode = HeaterMode.WINTER  # Register 0b55
-                controller.manual_temperature = 25.0  # Register 0b8d
-
-                # Save should write to both registers
-                result = await controller.save()
+                result = await controller.set_manual_heating(25.0)
                 assert result is True
 
 
@@ -186,7 +152,7 @@ class TestErrorRecovery:
     """Tests for error handling and recovery."""
 
     @pytest.mark.asyncio
-    async def test_network_error_during_read(self, api_base_url, registry):
+    async def test_network_error_during_read(self, api_base_url):
         """Test handling of network error during read."""
         with aioresponses() as m:
             read_url = f"{api_base_url}/0b00/256"
@@ -194,55 +160,37 @@ class TestErrorRecovery:
 
             async with aiohttp.ClientSession() as session:
                 backend = HttpRegisterBackend(session, api_base_url)
-                controller = HeaterController(backend=backend, registry=registry)
+                controller = Ekco_M3(backend=backend)
 
-                # Refresh should handle error gracefully
                 await controller.refresh()
 
-                # Settings should remain empty or handle gracefully
-                assert (
-                    len(controller._settings) == 0
-                    or controller._settings.get("heater_mode") is None
-                )
+                assert len(controller._registers) == 0
 
     @pytest.mark.asyncio
-    async def test_network_error_during_write_preserves_pending(
-        self, api_base_url, sample_registers, registry
+    async def test_network_error_during_write_returns_false(
+        self, api_base_url, sample_registers
     ):
-        """Test that network error during write preserves pending writes."""
+        """Test that set_heater_mode returns False when write fails."""
         registers = sample_registers.copy()
 
         with aioresponses() as m:
-            # Mock successful refresh
             read_url = f"{api_base_url}/0b00/256"
             m.get(read_url, payload={"regs": registers})
 
-            # Mock failed write
             write_url = f"{api_base_url}/0b55"
             m.post(write_url, exception=aiohttp.ClientError("Write error"))
-            # Mock read for save
-            read_single_url = f"{api_base_url}/0b55/1"
-            m.get(read_single_url, payload={"regs": {"0b55": registers["0b55"]}})
 
             async with aiohttp.ClientSession() as session:
                 backend = HttpRegisterBackend(session, api_base_url)
-                controller = HeaterController(backend=backend, registry=registry)
+                controller = Ekco_M3(backend=backend)
                 await controller.refresh()
 
-                # Modify setting
-                controller.heater_mode = HeaterMode.WINTER
-                assert len(controller._pending_writes) > 0
-
-                # Save should fail
-                result = await controller.save()
+                result = await controller.set_heater_mode(HeaterMode.WINTER)
                 assert result is False
-
-                # Pending writes should still be present
-                assert len(controller._pending_writes) > 0
 
     @pytest.mark.asyncio
     async def test_invalid_register_data_handles_gracefully(
-        self, api_base_url, registry
+        self, api_base_url
     ):
         """Test handling of invalid register data."""
         invalid_registers = {"0b55": "invalid"}
@@ -253,51 +201,36 @@ class TestErrorRecovery:
 
             async with aiohttp.ClientSession() as session:
                 backend = HttpRegisterBackend(session, api_base_url)
-                controller = HeaterController(backend=backend, registry=registry)
+                controller = Ekco_M3(backend=backend)
 
-                # Should handle decode errors gracefully
                 await controller.refresh()
 
-                # Some settings may be None
-                assert (
-                    controller._settings.get("heater_mode") is None
-                    or len(controller._settings) > 0
-                )
+                assert controller.heater_mode is None or len(controller._registers) > 0
 
     @pytest.mark.asyncio
     async def test_partial_write_failures(
-        self, api_base_url, sample_registers, registry
+        self, api_base_url, sample_registers
     ):
-        """Test handling of partial write failures."""
+        """Test handling of partial write failures in set_manual_heating."""
         registers = sample_registers.copy()
 
         with aioresponses() as m:
-            # Mock refresh
             read_url = f"{api_base_url}/0b00/256"
             m.get(read_url, payload={"regs": registers})
 
-            # Mock one successful write, one failed
             write_url_55 = f"{api_base_url}/0b55"
+            write_url_32 = f"{api_base_url}/0b32"
             write_url_8d = f"{api_base_url}/0b8d"
             m.post(write_url_55, payload={"status": "0"})
+            m.post(write_url_32, payload={"status": "0"})
             m.post(write_url_8d, exception=aiohttp.ClientError("Write error"))
-            # Mock reads for save
-            read_url_55 = f"{api_base_url}/0b55/1"
-            read_url_8d = f"{api_base_url}/0b8d/1"
-            m.get(read_url_55, payload={"regs": {"0b55": registers["0b55"]}})
-            m.get(read_url_8d, payload={"regs": {"0b8d": registers["0b8d"]}})
 
             async with aiohttp.ClientSession() as session:
                 backend = HttpRegisterBackend(session, api_base_url)
-                controller = HeaterController(backend=backend, registry=registry)
+                controller = Ekco_M3(backend=backend)
                 await controller.refresh()
 
-                # Modify settings in different registers
-                controller.heater_mode = HeaterMode.WINTER  # Register 0b55 (success)
-                controller.manual_temperature = 25.0  # Register 0b8d (failure)
-
-                # Save should fail overall
-                result = await controller.save()
+                result = await controller.set_manual_heating(25.0)
                 assert result is False
 
 
@@ -305,118 +238,75 @@ class TestRegisterCaching:
     """Tests for register caching behavior."""
 
     @pytest.mark.asyncio
-    async def test_cache_used_for_subsequent_writes(
-        self, api_base_url, sample_registers, registry
+    async def test_cache_used_for_writes(
+        self, api_base_url, sample_registers
     ):
-        """Test that cache is used for subsequent writes to same register."""
+        """Test that _registers is used for read-modify-write."""
         registers = sample_registers.copy()
 
         with aioresponses() as m:
-            # Mock refresh
             read_url = f"{api_base_url}/0b00/256"
             m.get(read_url, payload={"regs": registers})
 
-            # Mock save - should only write once (using cache)
-            write_url = f"{api_base_url}/0b55"
-            m.post(write_url, payload={"status": "0"})
-            # Should NOT need to read register (using cache)
+            write_url_55 = f"{api_base_url}/0b55"
+            m.post(write_url_55, payload={"status": "0"})
 
             async with aiohttp.ClientSession() as session:
                 backend = HttpRegisterBackend(session, api_base_url)
-                controller = HeaterController(backend=backend, registry=registry)
+                controller = Ekco_M3(backend=backend)
                 await controller.refresh()
 
-                # Verify cache is populated
-                assert "0b55" in controller._register_cache
+                assert "0b55" in controller._registers
 
-                # Modify setting
-                controller.heater_mode = HeaterMode.WINTER
-
-                # Count GET requests before save
-                get_requests_before = [
-                    req for req in m.requests.keys()
-                    if req[0] == "GET"
-                ]
-                initial_get_count = len(get_requests_before)
-                assert initial_get_count > 0, "Refresh should have made GET requests"
-
-                # Save should use cache, not read
-                result = await controller.save()
+                result = await controller.set_heater_mode(HeaterMode.WINTER)
                 assert result is True
-                
-                # Verify no additional GET requests were made during save (cache was used)
-                get_requests_after = [
-                    req for req in m.requests.keys()
-                    if req[0] == "GET"
-                ]
-                final_get_count = len(get_requests_after)
-                # Should have same number of GET requests (no additional reads during save)
-                assert final_get_count == initial_get_count, "Save should not have made additional GET requests"
 
     @pytest.mark.asyncio
     async def test_cache_invalidated_on_refresh(
-        self, api_base_url, sample_registers, registry
+        self, api_base_url, sample_registers
     ):
         """Test that cache is invalidated on refresh."""
         registers = sample_registers.copy()
         new_registers = registers.copy()
-        new_registers["0b55"] = "2000"  # Different value
+        new_registers["0b55"] = "2000"
 
         with aioresponses() as m:
-            # Mock first refresh
             read_url = f"{api_base_url}/0b00/256"
             m.get(read_url, payload={"regs": registers})
-
-            # Mock second refresh with different values
             m.get(read_url, payload={"regs": new_registers})
 
             async with aiohttp.ClientSession() as session:
                 backend = HttpRegisterBackend(session, api_base_url)
-                controller = HeaterController(backend=backend, registry=registry)
+                controller = Ekco_M3(backend=backend)
 
-                # First refresh
                 await controller.refresh()
-                original_value = controller._register_cache.get("0b55")
+                original_value = controller._registers.get("0b55")
 
-                # Second refresh
                 await controller.refresh()
-                new_value = controller._register_cache.get("0b55")
+                new_value = controller._registers.get("0b55")
 
-                # Cache should be updated
                 assert original_value != new_value
 
     @pytest.mark.asyncio
     async def test_cache_updated_after_successful_write(
-        self, api_base_url, sample_registers, registry
+        self, api_base_url, sample_registers
     ):
         """Test that cache is updated after successful write."""
         registers = sample_registers.copy()
 
         with aioresponses() as m:
-            # Mock refresh
             read_url = f"{api_base_url}/0b00/256"
             m.get(read_url, payload={"regs": registers})
 
-            # Mock save
-            write_url = f"{api_base_url}/0b55"
-            m.post(write_url, payload={"status": "0"})
-            # Mock read for save (cache miss scenario)
-            read_single_url = f"{api_base_url}/0b55/1"
-            m.get(read_single_url, payload={"regs": {"0b55": registers["0b55"]}})
+            write_url_55 = f"{api_base_url}/0b55"
+            m.post(write_url_55, payload={"status": "0"})
 
             async with aiohttp.ClientSession() as session:
                 backend = HttpRegisterBackend(session, api_base_url)
-                controller = HeaterController(backend=backend, registry=registry)
+                controller = Ekco_M3(backend=backend)
                 await controller.refresh()
 
-                # Clear cache to force read
-                controller._register_cache.clear()
+                result = await controller.set_heater_mode(HeaterMode.WINTER)
+                assert result is True
 
-                # Modify setting
-                controller.heater_mode = HeaterMode.WINTER
-
-                # Save should update cache
-                await controller.save()
-
-                # Cache should be updated with new value
-                assert "0b55" in controller._register_cache
+                assert "0b55" in controller._registers

--- a/tests/integration/test_mock_mode.py
+++ b/tests/integration/test_mock_mode.py
@@ -27,7 +27,7 @@ class TestYamlBackendFullCycle:
 
         await controller.refresh()
 
-        assert len(controller._registers) > 0
+        assert controller.heater_mode is not None
 
         result = await controller.set_heater_mode(HeaterMode.MANUAL)
         assert result is True
@@ -69,11 +69,7 @@ class TestYamlBackendFullCycle:
         controller = _controller_for_state_file(str(state_file))
         await controller.refresh()
 
-        assert len(controller._registers) > 0
-        assert (
-            controller.heater_mode == HeaterMode.WINTER
-            or controller.heater_mode is not None
-        )
+        assert controller.heater_mode == HeaterMode.WINTER
 
     @pytest.mark.asyncio
     async def test_state_survives_controller_recreation(self, tmp_path):
@@ -153,14 +149,15 @@ class TestYamlBackendVsRealAPI:
         state_file = tmp_path / "state.yaml"
         state_file.parent.mkdir(parents=True, exist_ok=True)
         test_state = {"0b55": "d700", "0b51": "0500"}
+        for reg_value in test_state.values():
+            assert isinstance(reg_value, str)
+            assert len(reg_value) == 4
+            assert all(c in "0123456789abcdef" for c in reg_value.lower())
+
         with open(state_file, "w") as f:
             yaml.dump(test_state, f)
 
         controller = _controller_for_state_file(str(state_file))
         await controller.refresh()
 
-        assert len(controller._registers) > 0
-        for reg_value in controller._registers.values():
-            assert isinstance(reg_value, str)
-            assert len(reg_value) == 4
-            assert all(c in "0123456789abcdef" for c in reg_value.lower())
+        assert controller.heater_mode is not None

--- a/tests/integration/test_mock_mode.py
+++ b/tests/integration/test_mock_mode.py
@@ -3,35 +3,33 @@
 import pytest
 import yaml
 
-from kospel_cmi.controller.api import HeaterController
+from kospel_cmi.controller.device import Ekco_M3
 from kospel_cmi.kospel.backend import YamlRegisterBackend
 from kospel_cmi.registers.enums import HeaterMode
 
 
-def _controller_for_state_file(state_file: str, registry: dict) -> HeaterController:
-    """Create HeaterController with YamlRegisterBackend for the given state file."""
+def _controller_for_state_file(state_file: str) -> Ekco_M3:
+    """Create Ekco_M3 with YamlRegisterBackend for the given state file."""
     backend = YamlRegisterBackend(state_file=state_file)
-    return HeaterController(backend=backend, registry=registry)
+    return Ekco_M3(backend=backend)
 
 
 class TestYamlBackendFullCycle:
     """Tests for complete cycle with YAML backend."""
 
     @pytest.mark.asyncio
-    async def test_yaml_backend_full_cycle(self, tmp_path, registry):
+    async def test_yaml_backend_full_cycle(self, tmp_path):
         """Test complete cycle with YAML backend."""
         state_file = tmp_path / "state.yaml"
         state_file.parent.mkdir(parents=True, exist_ok=True)
 
-        controller = _controller_for_state_file(str(state_file), registry)
+        controller = _controller_for_state_file(str(state_file))
 
         await controller.refresh()
 
-        assert len(controller._settings) > 0
+        assert len(controller._registers) > 0
 
-        controller.heater_mode = HeaterMode.MANUAL
-
-        result = await controller.save()
+        result = await controller.set_heater_mode(HeaterMode.MANUAL)
         assert result is True
 
         assert state_file.exists()
@@ -41,16 +39,15 @@ class TestYamlBackendFullCycle:
             assert len(loaded_state) > 0
 
     @pytest.mark.asyncio
-    async def test_state_persisted_on_write(self, tmp_path, registry):
+    async def test_state_persisted_on_write(self, tmp_path):
         """Test that write operations update YAML file."""
         state_file = tmp_path / "state.yaml"
         state_file.parent.mkdir(parents=True, exist_ok=True)
 
-        controller = _controller_for_state_file(str(state_file), registry)
+        controller = _controller_for_state_file(str(state_file))
 
         await controller.refresh()
-        controller.heater_mode = HeaterMode.WINTER
-        await controller.save()
+        await controller.set_heater_mode(HeaterMode.WINTER)
 
         assert state_file.exists()
         with open(state_file, "r") as f:
@@ -61,7 +58,7 @@ class TestYamlBackendFullCycle:
             )
 
     @pytest.mark.asyncio
-    async def test_state_loaded_on_next_run(self, tmp_path, registry):
+    async def test_state_loaded_on_next_run(self, tmp_path):
         """Test that state is loaded on next run."""
         state_file = tmp_path / "state.yaml"
         state_file.parent.mkdir(parents=True, exist_ok=True)
@@ -69,32 +66,31 @@ class TestYamlBackendFullCycle:
         with open(state_file, "w") as f:
             yaml.dump(initial_state, f)
 
-        controller = _controller_for_state_file(str(state_file), registry)
+        controller = _controller_for_state_file(str(state_file))
         await controller.refresh()
 
-        assert len(controller._settings) > 0
+        assert len(controller._registers) > 0
         assert (
             controller.heater_mode == HeaterMode.WINTER
             or controller.heater_mode is not None
         )
 
     @pytest.mark.asyncio
-    async def test_state_survives_controller_recreation(self, tmp_path, registry):
+    async def test_state_survives_controller_recreation(self, tmp_path):
         """Test that state survives controller recreation."""
         state_file = tmp_path / "state.yaml"
         state_file.parent.mkdir(parents=True, exist_ok=True)
 
-        controller1 = _controller_for_state_file(str(state_file), registry)
+        controller1 = _controller_for_state_file(str(state_file))
         await controller1.refresh()
-        controller1.heater_mode = HeaterMode.WINTER
-        await controller1.save()
+        await controller1.set_heater_mode(HeaterMode.WINTER)
 
-        controller2 = _controller_for_state_file(str(state_file), registry)
+        controller2 = _controller_for_state_file(str(state_file))
         await controller2.refresh()
 
         assert (
             controller2.heater_mode == HeaterMode.WINTER
-            or len(controller2._settings) > 0
+            or len(controller2._registers) > 0
         )
 
 
@@ -102,15 +98,14 @@ class TestYamlBackendStatePersistence:
     """Tests for state file persistence with YAML backend."""
 
     @pytest.mark.asyncio
-    async def test_write_operations_update_yaml(self, tmp_path, registry):
+    async def test_write_operations_update_yaml(self, tmp_path):
         """Test that write operations update YAML file."""
         state_file = tmp_path / "state.yaml"
         state_file.parent.mkdir(parents=True, exist_ok=True)
 
-        controller = _controller_for_state_file(str(state_file), registry)
+        controller = _controller_for_state_file(str(state_file))
         await controller.refresh()
-        controller.manual_temperature = 25.0
-        await controller.save()
+        await controller.set_manual_temperature(25.0)
 
         assert state_file.exists()
         with open(state_file, "r") as f:
@@ -118,7 +113,7 @@ class TestYamlBackendStatePersistence:
             assert loaded_state is not None
 
     @pytest.mark.asyncio
-    async def test_read_operations_load_from_yaml(self, tmp_path, registry):
+    async def test_read_operations_load_from_yaml(self, tmp_path):
         """Test that read operations load from YAML file."""
         state_file = tmp_path / "state.yaml"
         state_file.parent.mkdir(parents=True, exist_ok=True)
@@ -126,7 +121,7 @@ class TestYamlBackendStatePersistence:
         with open(state_file, "w") as f:
             yaml.dump(pre_state, f)
 
-        controller = _controller_for_state_file(str(state_file), registry)
+        controller = _controller_for_state_file(str(state_file))
         await controller.refresh()
 
         temp = controller.manual_temperature
@@ -134,11 +129,11 @@ class TestYamlBackendStatePersistence:
 
 
 class TestYamlBackendVsRealAPI:
-    """Tests for consistency of YAML backend with registry."""
+    """Tests for consistency of YAML backend."""
 
     @pytest.mark.asyncio
     async def test_same_operations_produce_same_results(
-        self, tmp_path, sample_registers, registry
+        self, tmp_path, sample_registers
     ):
         """Test that same operations produce expected results with YAML backend."""
         state_file = tmp_path / "state.yaml"
@@ -146,15 +141,14 @@ class TestYamlBackendVsRealAPI:
         with open(state_file, "w") as f:
             yaml.dump(sample_registers, f)
 
-        controller = _controller_for_state_file(str(state_file), registry)
+        controller = _controller_for_state_file(str(state_file))
         await controller.refresh()
-        controller.heater_mode = HeaterMode.WINTER
-        await controller.save()
+        await controller.set_heater_mode(HeaterMode.WINTER)
 
         assert controller.heater_mode == HeaterMode.WINTER
 
     @pytest.mark.asyncio
-    async def test_register_values_match_expected_format(self, tmp_path, registry):
+    async def test_register_values_match_expected_format(self, tmp_path):
         """Test that register values match expected format."""
         state_file = tmp_path / "state.yaml"
         state_file.parent.mkdir(parents=True, exist_ok=True)
@@ -162,23 +156,11 @@ class TestYamlBackendVsRealAPI:
         with open(state_file, "w") as f:
             yaml.dump(test_state, f)
 
-        controller = _controller_for_state_file(str(state_file), registry)
+        controller = _controller_for_state_file(str(state_file))
         await controller.refresh()
 
-        assert len(controller._register_cache) > 0
-        for reg_value in controller._register_cache.values():
+        assert len(controller._registers) > 0
+        for reg_value in controller._registers.values():
             assert isinstance(reg_value, str)
             assert len(reg_value) == 4
             assert all(c in "0123456789abcdef" for c in reg_value.lower())
-
-    @pytest.mark.asyncio
-    async def test_yaml_backend_consistent_with_registry(self, tmp_path, registry):
-        """Test that YAML backend behaves consistently with registry definitions."""
-        state_file = tmp_path / "state.yaml"
-        state_file.parent.mkdir(parents=True, exist_ok=True)
-
-        controller = _controller_for_state_file(str(state_file), registry)
-        await controller.refresh()
-
-        for setting_name in registry.keys():
-            getattr(controller, setting_name, None)

--- a/tests/integration/test_water_heater_registers.py
+++ b/tests/integration/test_water_heater_registers.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from kospel_cmi.controller.api import HeaterController
+from kospel_cmi.controller.device import Ekco_M3
 
 
 class TestWaterHeaterRegisters:
@@ -10,7 +10,7 @@ class TestWaterHeaterRegisters:
 
     @pytest.mark.asyncio
     async def test_water_current_temperature_decoded(
-        self, heater_controller_with_registers: HeaterController
+        self, heater_controller_with_registers: Ekco_M3
     ) -> None:
         """water_current_temperature is decoded from register 0b4a."""
         controller = heater_controller_with_registers
@@ -20,7 +20,7 @@ class TestWaterHeaterRegisters:
 
     @pytest.mark.asyncio
     async def test_pressure_decoded_from_0b4e(
-        self, heater_controller_with_registers: HeaterController
+        self, heater_controller_with_registers: Ekco_M3
     ) -> None:
         """pressure is decoded from register 0b4e (scaled_x100)."""
         controller = heater_controller_with_registers
@@ -30,7 +30,7 @@ class TestWaterHeaterRegisters:
 
     @pytest.mark.asyncio
     async def test_cwu_temperatures_decoded(
-        self, heater_controller_with_registers: HeaterController
+        self, heater_controller_with_registers: Ekco_M3
     ) -> None:
         """cwu_temperature_economy and cwu_temperature_comfort are decoded."""
         controller = heater_controller_with_registers
@@ -39,7 +39,7 @@ class TestWaterHeaterRegisters:
 
     @pytest.mark.asyncio
     async def test_supply_setpoint_decoded(
-        self, heater_controller_with_registers: HeaterController
+        self, heater_controller_with_registers: Ekco_M3
     ) -> None:
         """supply_setpoint (CWU) is decoded from register 0b2f."""
         controller = heater_controller_with_registers
@@ -47,7 +47,7 @@ class TestWaterHeaterRegisters:
 
     @pytest.mark.asyncio
     async def test_room_setpoint_decoded(
-        self, heater_controller_with_registers: HeaterController
+        self, heater_controller_with_registers: Ekco_M3
     ) -> None:
         """room_setpoint (CO) is decoded from register 0b31."""
         controller = heater_controller_with_registers

--- a/tests/test_climate_entity.py
+++ b/tests/test_climate_entity.py
@@ -154,12 +154,12 @@ class TestClimateSetTemperature:
         """async_set_temperature does nothing when manual mode is off."""
         mock_controller = MagicMock()
         mock_controller.heater_mode = HeaterMode.WINTER
-        mock_controller.save = AsyncMock()
+        mock_controller.set_manual_heating = AsyncMock()
         mock_coordinator.data = mock_controller
 
         await climate_entity.async_set_temperature(temperature=25.0)
 
-        mock_controller.save.assert_not_called()
+        mock_controller.set_manual_heating.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_set_temperature_calls_set_manual_heating_when_manual_mode_on(

--- a/tests/test_climate_entity.py
+++ b/tests/test_climate_entity.py
@@ -134,7 +134,7 @@ class TestClimateSupportedFeatures:
     def test_supported_features_includes_target_temp_always(
         self, climate_entity, mock_coordinator
     ) -> None:
-        """TARGET_TEMPERATURE always included so target is displayed; only settable in manual mode."""
+        """TARGET_TEMPERATURE always included so target is displayed and settable."""
         for mode in (HeaterMode.WINTER, HeaterMode.MANUAL):
             mock_controller = MagicMock()
             mock_controller.heater_mode = mode
@@ -145,27 +145,31 @@ class TestClimateSupportedFeatures:
 
 
 class TestClimateSetTemperature:
-    """Tests for async_set_temperature (no-op when manual mode off)."""
+    """Tests for async_set_temperature (delegates to set_manual_heating on the device)."""
 
     @pytest.mark.asyncio
-    async def test_set_temperature_no_op_when_manual_mode_off(
+    async def test_set_temperature_calls_set_manual_heating_from_winter_mode(
         self, climate_entity, mock_coordinator
     ) -> None:
-        """async_set_temperature does nothing when manual mode is off."""
+        """async_set_temperature calls set_manual_heating even when not already in MANUAL."""
         mock_controller = MagicMock()
         mock_controller.heater_mode = HeaterMode.WINTER
-        mock_controller.set_manual_heating = AsyncMock()
+        mock_controller.set_manual_heating = AsyncMock(return_value=True)
+        mock_coordinator.async_request_refresh = AsyncMock()
         mock_coordinator.data = mock_controller
+        climate_entity.async_write_ha_state = MagicMock()
 
-        await climate_entity.async_set_temperature(temperature=25.0)
+        with patch("custom_components.kospel.climate.asyncio.sleep", new_callable=AsyncMock):
+            await climate_entity.async_set_temperature(temperature=25.0)
 
-        mock_controller.set_manual_heating.assert_not_called()
+        mock_controller.set_manual_heating.assert_called_once_with(25.0)
+        mock_coordinator.async_request_refresh.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_set_temperature_calls_set_manual_heating_when_manual_mode_on(
+    async def test_set_temperature_calls_set_manual_heating_when_already_manual(
         self, climate_entity, mock_coordinator
     ) -> None:
-        """async_set_temperature calls set_manual_heating when manual mode is on."""
+        """async_set_temperature still calls set_manual_heating when already in MANUAL."""
         mock_controller = MagicMock()
         mock_controller.heater_mode = HeaterMode.MANUAL
         mock_controller.set_manual_heating = AsyncMock(return_value=True)
@@ -209,15 +213,6 @@ class TestClimateHvacAction:
         """hvac_action returns OFF when co_heating_status is DISABLED."""
         mock_controller = MagicMock()
         mock_controller.co_heating_status = HeatingStatus.DISABLED
-        mock_coordinator.data = mock_controller
-
-        assert climate_entity.hvac_action == HVACAction.OFF
-
-    def test_hvac_action_off_when_co_heating_status_missing(
-        self, climate_entity, mock_coordinator
-    ) -> None:
-        """hvac_action returns OFF when co_heating_status is missing (fallback to IDLE)."""
-        mock_controller = object()  # No co_heating_status attribute
         mock_coordinator.data = mock_controller
 
         assert climate_entity.hvac_action == HVACAction.OFF

--- a/tests/test_water_heater_entity.py
+++ b/tests/test_water_heater_entity.py
@@ -132,12 +132,13 @@ class TestWaterHeaterTargetTemperature:
     def test_target_temperature_returns_none_when_setpoint_missing(
         self, water_heater_entity, mock_coordinator
     ) -> None:
-        """target_temperature returns None when setpoint not in controller."""
-        mock_controller = MagicMock(spec=[])  # No cwu_temperature_* attributes
+        """target_temperature returns None when active setpoint decodes to None."""
+        mock_controller = MagicMock()
+        mock_controller.cwu_mode = CwuMode.ECONOMY
+        mock_controller.cwu_temperature_economy = None
         mock_coordinator.data = mock_controller
 
-        result = water_heater_entity.target_temperature
-        assert result is None
+        assert water_heater_entity.target_temperature is None
 
 
 class TestWaterHeaterCurrentOperation:

--- a/uv.lock
+++ b/uv.lock
@@ -397,7 +397,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.3" },
-    { name = "kospel-cmi-lib", specifier = "==0.1.0a11" },
+    { name = "kospel-cmi-lib", specifier = "==0.1.0a12" },
 ]
 
 [package.metadata.requires-dev]
@@ -433,7 +433,7 @@ wheels = [
 
 [[package]]
 name = "kospel-cmi-lib"
-version = "0.1.0a11"
+version = "0.1.0a12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -441,9 +441,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/8e/22fec30e214d1a8a8a8fa9914d698f8b32ed62afe494c8649309117fff2d/kospel_cmi_lib-0.1.0a11.tar.gz", hash = "sha256:fd7acae6d73c64e0ade941d7330140fb796fb7dc76f0fe1b15191bcf4bea512a", size = 36558, upload-time = "2026-03-10T18:11:54.458Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/e1/4d58e7ef725518ff912782efc29fc9d7f2fed5fb0a5a1250aad2da3eb6a9/kospel_cmi_lib-0.1.0a12.tar.gz", hash = "sha256:998bfe414d79f6df1d9d3c8c623d56ddeb657001ee24fb170ef4c5eccaf8288c", size = 32140, upload-time = "2026-03-22T14:11:51.312Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/06/5461962a552a12c22f72128bada57cc82eb34b6302f732a2fec810825791/kospel_cmi_lib-0.1.0a11-py3-none-any.whl", hash = "sha256:445fd3b54afbe1497f26cc8e8ebc1adc9e049148fa5879d26ce6799b7391008b", size = 49361, upload-time = "2026-03-10T18:11:52.898Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/c6/81ff71e38e38f0e219d9341ee351c0a6fb297864f63b9c09175f6eff58b1/kospel_cmi_lib-0.1.0a12-py3-none-any.whl", hash = "sha256:9c0cd3da0383ef62b5679a48c357e805fae46f6a7afc14d24dd49f47688590de", size = 44102, upload-time = "2026-03-22T14:11:49.736Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Migrate integration to `Ekco_M3` and kospel-cmi-lib 0.1.0a12

## Summary

Replaces the generic **`HeaterController` + `load_registry`** setup with the library’s **`Ekco_M3`** device class (register map is built into the device). Bumps **`kospel-cmi-lib`** to **`0.1.0a12`** and updates entities, coordinator typing, tests, and docs to match the new API (immediate writes via **`set_heater_mode`** / **`set_manual_heating`** instead of property mutation + **`save()`**).

## Motivation

- Align the Home Assistant layer with **kospel-cmi-lib**’s device-oriented API and simplify setup (**backend only**, no registry wiring in the integration).
- Fix manual heating / target temperature flow: changing target temperature calls **`set_manual_heating`**, which puts the heater in manual mode as defined by the library.
- Keep tests and integration scenarios in sync with how the HTTP/YAML backends and writes behave today.

## What changed

### Integration

- **`__init__.py`**: `Ekco_M3(backend=...)` instead of `HeaterController` + `load_registry`.
- **`coordinator.py`**: `DataUpdateCoordinator[Ekco_M3]` and updated docstrings.
- **`manifest.json`** / **`pyproject.toml`** / **`uv.lock`**: `kospel-cmi-lib==0.1.0a12`.

### Climate

- Types: `TypedDict` + `Unpack` for `async_set_temperature` kwargs (no `Any`).
- Uses **`controller.heater_mode or HeaterMode.OFF`**, direct attributes where applicable, and **`set_heater_mode`** / **`set_manual_heating`** for writes.
- **`supported_features`**: target temperature is shown and changes manual heating when adjusted (no longer gated on “already in manual” before calling **`set_manual_heating`**).

### Water heater

- Declares **`OPERATION_MODE`** and **`TARGET_TEMPERATURE`** so the UI can show current operation and temperatures; **`async_set_temperature`** / **`async_set_operation_mode`** are intentionally no-ops (DHW/CWU is driven by device presets and the climate entity, not these card controls). Documented in the class docstring and next to **`_attr_supported_features`**.
- **`current_operation`**: treat as off when **`is_water_heater_enabled`** is not **`ENABLED`**; safer mapping when **`cwu_mode`** is missing.

### Sensors

- **Power**: native **W** (library reports kW) for Energy dashboard compatibility.
- **Temperature sensors**: explicit **`Ekco_M3`** getters instead of **`getattr` by string** for type clarity and maintainability.
- Pressure / valve / heating status: direct attributes where straightforward.

### Documentation

- **`docs/architecture.md`**, **`docs/technical.md`**: diagram and import examples updated for **`Ekco_M3`** (no registry in the integration).

### Tests

- **`conftest.py`**: fixtures build **`Ekco_M3`** without a registry fixture.
- **Integration tests** (`test_api_communication.py`, `test_mock_mode.py`, register tests): updated mocks and expectations for immediate writes and **`Ekco_M3`** internals.
- **Unit tests** (`test_climate_entity.py`, `test_water_heater_entity.py`): aligned with new behaviour.

## How to test

```bash
uv sync --all-groups
uv run python -m pytest tests/ -v
```

All tests should pass locally.

## Notes for reviewers

- Integration tests may assert on library-internal details (e.g. register backing); acceptable for now but could be revisited if the library exposes a stable public signal.
- Water heater UI may still show settable controls; behaviour is documented as display-oriented with writes ignored by design.
