### PR TITLE
Apply hotfix

### DIFF
--- a/custom_components/kospel/sensor.py
+++ b/custom_components/kospel/sensor.py
@@ -39,10 +39,13 @@ async def async_setup_entry(
         ("supply_setpoint", "supply_setpoint"),
     ]
 
-    for unique_id_suffix, setting_name in temperature_sensors:
+    for unique_id_suffix, attr_name in temperature_sensors:
         entities.append(
             KospelTemperatureSensor(
-                coordinator, entry, unique_id_suffix, setting_name
+                coordinator,
+                entry,
+                unique_id_suffix,
+                lambda c, name=attr_name: getattr(c, name, None),
             )
         )
 

--- a/tests/test_sensor_entity.py
+++ b/tests/test_sensor_entity.py
@@ -1,0 +1,125 @@
+"""Tests for Kospel temperature sensor (native_value via value getter)."""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# Mock homeassistant before importing integration modules.
+class _HAModule:
+    __path__ = []
+    __file__ = ""
+    __name__ = "homeassistant"
+    __spec__ = None
+
+
+_ha = _HAModule()
+sys.modules["homeassistant"] = _ha
+sys.modules["homeassistant.config_entries"] = MagicMock()
+sys.modules["homeassistant.components"] = MagicMock()
+const_mock = MagicMock()
+const_mock.UnitOfTemperature = MagicMock()
+const_mock.UnitOfTemperature.CELSIUS = "°C"
+const_mock.UnitOfPressure = MagicMock()
+const_mock.UnitOfPower = MagicMock()
+sys.modules["homeassistant.const"] = const_mock
+sys.modules["homeassistant.core"] = MagicMock()
+sys.modules["homeassistant.exceptions"] = MagicMock()
+sys.modules["homeassistant.helpers"] = MagicMock()
+sys.modules["homeassistant.helpers.entity"] = MagicMock()
+sys.modules["homeassistant.helpers.entity_platform"] = MagicMock()
+sys.modules["homeassistant.helpers.update_coordinator"] = MagicMock()
+
+
+def _device_info(**kwargs):
+    return kwargs
+
+
+sys.modules["homeassistant.helpers.entity"].DeviceInfo = _device_info
+
+
+class _CoordinatorEntityBase:
+    """Minimal CoordinatorEntity stand-in for testing."""
+
+    def __init__(self, coordinator):
+        self.coordinator = coordinator
+
+    @classmethod
+    def __class_getitem__(cls, item):
+        return cls
+
+
+class _SensorEntityBase:
+    """Minimal SensorEntity stand-in for testing."""
+
+    pass
+
+
+sensor_mock = MagicMock()
+sensor_mock.SensorEntity = _SensorEntityBase
+sensor_mock.SensorDeviceClass = MagicMock()
+sensor_mock.SensorDeviceClass.TEMPERATURE = "temperature"
+sensor_mock.SensorStateClass = MagicMock()
+sensor_mock.SensorStateClass.MEASUREMENT = "measurement"
+sys.modules["homeassistant.components.sensor"] = sensor_mock
+
+sys.modules["homeassistant.helpers.update_coordinator"].CoordinatorEntity = (
+    _CoordinatorEntityBase
+)
+
+from custom_components.kospel.sensor import KospelTemperatureSensor
+
+
+@pytest.fixture
+def mock_entry():
+    """Config entry with stable entry_id for unique_id."""
+    entry = MagicMock()
+    entry.data = {}
+    entry.entry_id = "test-entry-id"
+    return entry
+
+
+@pytest.fixture
+def mock_coordinator(mock_entry):
+    """Mock coordinator with configurable controller data."""
+    coordinator = MagicMock()
+    coordinator.entry = mock_entry
+    coordinator.last_update_success = True
+    return coordinator
+
+
+class TestKospelTemperatureSensorNativeValue:
+    """Tests for native_value reading controller attributes via getter."""
+
+    def test_native_value_returns_float_from_controller_attribute(
+        self, mock_coordinator, mock_entry
+    ) -> None:
+        """native_value returns the float from the bound Ekco_M3 attribute."""
+        mock_controller = MagicMock()
+        mock_controller.room_setpoint = 22.5
+        mock_coordinator.data = mock_controller
+
+        entity = KospelTemperatureSensor(
+            mock_coordinator,
+            mock_entry,
+            "room_setpoint",
+            lambda c, name="room_setpoint": getattr(c, name, None),
+        )
+
+        assert entity.native_value == 22.5
+
+    def test_native_value_returns_none_when_attribute_missing(
+        self, mock_coordinator, mock_entry
+    ) -> None:
+        """native_value returns None when attribute is absent."""
+        mock_controller = object()
+        mock_coordinator.data = mock_controller
+
+        entity = KospelTemperatureSensor(
+            mock_coordinator,
+            mock_entry,
+            "room_setpoint",
+            lambda c, name="room_setpoint": getattr(c, name, None),
+        )
+
+        assert entity.native_value is None


### PR DESCRIPTION
## Hotfix: temperature sensors — `TypeError: 'str' object is not callable`

### Summary

Fixes a regression where `KospelTemperatureSensor` received an attribute name **string** as the fourth constructor argument while the class expects a **`Callable[[Ekco_M3], float | None]`**. `native_value` then tried to call that string and raised `TypeError`, which blocked adding six temperature-related sensors and broke coordinator-driven updates (including climate temperature changes).

### Root cause

`async_setup_entry` passed `setting_name` (e.g. `"room_setpoint"`, `"supply_setpoint"`) into `KospelTemperatureSensor` as `_value_getter`. The implementation calls `self._value_getter(controller)`, so a string is invalid.

### Fix

In the temperature sensor setup loop, pass a getter that reads the controller attribute by name, with a default argument so the loop variable is captured correctly:

`lambda c, name=attr_name: getattr(c, name, None)`

### Tests

- Added `tests/test_sensor_entity.py` covering `native_value` for a present attribute and for a missing attribute (`None`).

### Verification

- `uv run python -m pytest tests/ -v` — all tests pass.

### Notes (out of scope)

- **`sensor.produkcja_dzienna` / template “expected a number”**: not part of this integration; likely a user template that depends on another entity or needs `unknown` handling.
- **WebSocket / `async_set_temperature` errors**: cascaded from the same sensor `native_value` failure during coordinator refresh; expected to clear with this fix.