### PR TITLE
Feature/selectors and power setting

### DIFF
--- a/custom_components/kospel/__init__.py
+++ b/custom_components/kospel/__init__.py
@@ -25,7 +25,7 @@ from kospel_cmi.kospel.backend import HttpRegisterBackend, YamlRegisterBackend
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[str] = ["climate", "number", "sensor", "water_heater"]
+PLATFORMS: list[str] = ["climate", "number", "select", "sensor", "water_heater"]
 
 
 async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:

--- a/custom_components/kospel/__init__.py
+++ b/custom_components/kospel/__init__.py
@@ -25,7 +25,7 @@ from kospel_cmi.kospel.backend import HttpRegisterBackend, YamlRegisterBackend
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[str] = ["climate", "sensor", "water_heater"]
+PLATFORMS: list[str] = ["climate", "number", "sensor", "water_heater"]
 
 
 async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:

--- a/custom_components/kospel/manifest.json
+++ b/custom_components/kospel/manifest.json
@@ -8,7 +8,7 @@
   "dependencies": ["http", "network"],
   "requirements": [
     "aiohttp>=3.13.3",
-    "kospel-cmi-lib==0.1.0a12"
+    "kospel-cmi-lib==0.1.0a13"
   ],
   "codeowners": ["@JanKrl"],
   "integration_type": "hub",

--- a/custom_components/kospel/number.py
+++ b/custom_components/kospel/number.py
@@ -1,0 +1,101 @@
+"""Number entities for Kospel integration (room preset temperatures)."""
+
+import asyncio
+
+from homeassistant.components.number import NumberDeviceClass, NumberEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from kospel_cmi.controller.device import Ekco_M3
+
+from .const import DOMAIN, get_device_info, get_device_identifier, get_refresh_delay_after_set
+from .coordinator import KospelDataUpdateCoordinator
+
+ROOM_PRESET_TEMP_MIN = 10.0
+ROOM_PRESET_TEMP_MAX = 25.0
+ROOM_PRESET_TEMP_STEP = 0.1
+
+# (translation_key / unique_id suffix / Ekco_M3 property name, async setter name)
+_ROOM_PRESET_ENTITIES: list[tuple[str, str]] = [
+    ("room_temperature_economy", "set_room_temperature_economy"),
+    ("room_temperature_comfort", "set_room_temperature_comfort"),
+    ("room_temperature_comfort_plus", "set_room_temperature_comfort_plus"),
+    ("room_temperature_comfort_minus", "set_room_temperature_comfort_minus"),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Kospel number entities."""
+    coordinator: KospelDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    entities: list[NumberEntity] = [
+        KospelRoomPresetNumberEntity(coordinator, entry, prop_key, setter_name)
+        for prop_key, setter_name in _ROOM_PRESET_ENTITIES
+    ]
+    async_add_entities(entities)
+
+
+class KospelRoomPresetNumberEntity(
+    CoordinatorEntity[KospelDataUpdateCoordinator], NumberEntity
+):
+    """Room preset temperature (economy / comfort / ±) as a read/write number."""
+
+    _attr_has_entity_name = True
+    _attr_native_min_value = ROOM_PRESET_TEMP_MIN
+    _attr_native_max_value = ROOM_PRESET_TEMP_MAX
+    _attr_native_step = ROOM_PRESET_TEMP_STEP
+    _attr_device_class = NumberDeviceClass.TEMPERATURE
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+
+    def __init__(
+        self,
+        coordinator: KospelDataUpdateCoordinator,
+        entry: ConfigEntry,
+        value_attr: str,
+        setter_name: str,
+    ) -> None:
+        """Initialize the room preset number entity.
+
+        Args:
+            coordinator: Data update coordinator.
+            entry: Config entry (device info and refresh delay options).
+            value_attr: Ekco_M3 property name (same as translation_key / unique suffix).
+            setter_name: Name of the async setter on Ekco_M3 (e.g. set_room_temperature_economy).
+        """
+        super().__init__(coordinator)
+        device_id = get_device_identifier(entry)
+        self._attr_unique_id = f"{device_id}_{value_attr}"
+        self._attr_translation_key = value_attr
+        self._attr_device_info = get_device_info(entry)
+        self._value_attr = value_attr
+        self._setter_name = setter_name
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current preset temperature from the controller."""
+        controller: Ekco_M3 = self.coordinator.data
+        return getattr(controller, self._value_attr, None)
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self.coordinator.last_update_success
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Write preset temperature to the heater and refresh coordinator data."""
+        controller: Ekco_M3 = self.coordinator.data
+        setter = getattr(controller, self._setter_name)
+        await setter(value)
+        self.async_write_ha_state()
+        await asyncio.sleep(get_refresh_delay_after_set(self.coordinator.entry))
+        await self.coordinator.async_request_refresh()
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self.async_write_ha_state()

--- a/custom_components/kospel/number.py
+++ b/custom_components/kospel/number.py
@@ -6,6 +6,7 @@ from homeassistant.components.number import NumberDeviceClass, NumberEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -44,9 +45,14 @@ async def async_setup_entry(
 class KospelRoomPresetNumberEntity(
     CoordinatorEntity[KospelDataUpdateCoordinator], NumberEntity
 ):
-    """Room preset temperature (economy / comfort / ±) as a read/write number."""
+    """Room preset temperature (economy / comfort / ±) as a read/write number.
+
+    Shown under device **Configuration** with other system-style setpoints
+    (e.g. max boiler power select).
+    """
 
     _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
     _attr_native_min_value = ROOM_PRESET_TEMP_MIN
     _attr_native_max_value = ROOM_PRESET_TEMP_MAX
     _attr_native_step = ROOM_PRESET_TEMP_STEP

--- a/custom_components/kospel/select.py
+++ b/custom_components/kospel/select.py
@@ -1,0 +1,102 @@
+"""Select entities for Kospel integration (boiler max power index)."""
+
+import asyncio
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from kospel_cmi.controller.device import Ekco_M3
+from kospel_cmi.registers.enums import BoilerMaxPowerIndex
+
+from .const import DOMAIN, get_device_info, get_device_identifier, get_refresh_delay_after_set
+from .coordinator import KospelDataUpdateCoordinator
+
+# Stable order 0..3 for HA options (do not rely on Enum iteration order).
+_BOILER_MAX_POWER_ORDER: tuple[BoilerMaxPowerIndex, ...] = (
+    BoilerMaxPowerIndex.KW_2,
+    BoilerMaxPowerIndex.KW_4,
+    BoilerMaxPowerIndex.KW_6,
+    BoilerMaxPowerIndex.KW_8,
+)
+
+_OPTION_FOR_INDEX: dict[BoilerMaxPowerIndex, str] = {
+    BoilerMaxPowerIndex.KW_2: "kw_2",
+    BoilerMaxPowerIndex.KW_4: "kw_4",
+    BoilerMaxPowerIndex.KW_6: "kw_6",
+    BoilerMaxPowerIndex.KW_8: "kw_8",
+}
+
+_INDEX_FOR_OPTION: dict[str, BoilerMaxPowerIndex] = {
+    v: k for k, v in _OPTION_FOR_INDEX.items()
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Kospel select entities."""
+    coordinator: KospelDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([KospelBoilerMaxPowerSelectEntity(coordinator, entry)])
+
+
+class KospelBoilerMaxPowerSelectEntity(
+    CoordinatorEntity[KospelDataUpdateCoordinator], SelectEntity
+):
+    """Boiler maximum power step (register 0b62); firmware updates kW display separately."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "boiler_max_power"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_options = [_OPTION_FOR_INDEX[idx] for idx in _BOILER_MAX_POWER_ORDER]
+
+    def __init__(
+        self,
+        coordinator: KospelDataUpdateCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the boiler max power select.
+
+        Args:
+            coordinator: Data update coordinator.
+            entry: Config entry (device info and refresh delay options).
+        """
+        super().__init__(coordinator)
+        device_id = get_device_identifier(entry)
+        self._attr_unique_id = f"{device_id}_boiler_max_power"
+        self._attr_device_info = get_device_info(entry)
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the selected option slug, or None if the device index is unknown."""
+        controller: Ekco_M3 = self.coordinator.data
+        index = controller.boiler_max_power_index
+        if index is None:
+            return None
+        return _OPTION_FOR_INDEX.get(index)
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self.coordinator.last_update_success
+
+    async def async_select_option(self, option: str) -> None:
+        """Write the selected power step to the heater and refresh coordinator data."""
+        chosen = _INDEX_FOR_OPTION.get(option)
+        if chosen is None:
+            raise ValueError(f"Invalid option: {option}")
+
+        controller: Ekco_M3 = self.coordinator.data
+        await controller.set_boiler_max_power_index(chosen)
+        self.async_write_ha_state()
+        await asyncio.sleep(get_refresh_delay_after_set(self.coordinator.entry))
+        await self.coordinator.async_request_refresh()
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self.async_write_ha_state()

--- a/custom_components/kospel/sensor.py
+++ b/custom_components/kospel/sensor.py
@@ -10,6 +10,7 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfPower, UnitOfPressure, UnitOfTemperature
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -49,6 +50,9 @@ async def async_setup_entry(
 
     # Power sensor
     entities.append(KospelPowerSensor(coordinator, entry))
+
+    # Configured max boiler power limit (kW from device, exposed as W)
+    entities.append(KospelMaxPowerLimitSensor(coordinator, entry))
 
     # Heating status sensors: (unique_id_suffix, setting_name)
     entities.append(
@@ -171,6 +175,41 @@ class KospelPowerSensor(KospelSensorEntity):
         if power_kw is None:
             return None
         return power_kw * 1000.0
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self.async_write_ha_state()
+
+
+class KospelMaxPowerLimitSensor(KospelSensorEntity):
+    """Configured maximum boiler power in watts.
+
+    Reads kW from register 0b34 and exposes W (same idea as ``KospelPowerSensor``).
+    Uses ``EntityCategory.DIAGNOSTIC`` because Home Assistant rejects CONFIG on
+    sensor entities; the max-power *select* remains CONFIG.
+    """
+
+    _attr_device_class = SensorDeviceClass.POWER
+    _attr_native_unit_of_measurement = UnitOfPower.WATT
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        coordinator: KospelDataUpdateCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the max power limit sensor."""
+        super().__init__(coordinator, entry, "max_power_limit", "max_power_limit")
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the configured max power in W (register 0b34, kW × 1000)."""
+        controller: Ekco_M3 = self.coordinator.data
+        limit_kw = controller.boiler_max_power_kw
+        if limit_kw is None:
+            return None
+        return float(limit_kw) * 1000.0
 
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""

--- a/custom_components/kospel/sensor.py
+++ b/custom_components/kospel/sensor.py
@@ -29,12 +29,7 @@ async def async_setup_entry(
 
     entities: list[SensorEntity] = []
 
-    # Temperature sensors: (unique_id_suffix, translation_key, setting_name)
     temperature_sensors = [
-        ("room_temperature_economy", "room_temperature_economy"),
-        ("room_temperature_comfort", "room_temperature_comfort"),
-        ("room_temperature_comfort_plus", "room_temperature_comfort_plus"),
-        ("room_temperature_comfort_minus", "room_temperature_comfort_minus"),
         ("room_setpoint", "room_setpoint"),
         ("supply_setpoint", "supply_setpoint"),
     ]
@@ -57,9 +52,7 @@ async def async_setup_entry(
 
     # Heating status sensors: (unique_id_suffix, setting_name)
     entities.append(
-        KospelHeatingStatusSensor(
-            coordinator, entry, "co_heating", "co_heating_status"
-        )
+        KospelHeatingStatusSensor(coordinator, entry, "co_heating", "co_heating_status")
     )
     entities.append(
         KospelHeatingStatusSensor(

--- a/custom_components/kospel/strings.json
+++ b/custom_components/kospel/strings.json
@@ -85,10 +85,18 @@
   },
   "entity": {
     "sensor": {
-      "room_setpoint": { "name": "Room Setpoint" },
-      "supply_setpoint": { "name": "DHW Setpoint" },
-      "pressure": { "name": "Pressure" },
-      "power": { "name": "Power" },
+      "room_setpoint": {
+        "name": "Room Setpoint"
+      },
+      "supply_setpoint": {
+        "name": "DHW Setpoint"
+      },
+      "pressure": {
+        "name": "Pressure"
+      },
+      "power": {
+        "name": "Power"
+      },
       "co_heating": {
         "name": "CO Heating",
         "state": {
@@ -111,16 +119,29 @@
           "DHW": "DHW",
           "CO": "CO"
         }
+      },
+      "max_power_limit": {
+        "name": "Max power limit"
       }
     },
     "number": {
-      "room_temperature_economy": { "name": "Eco" },
-      "room_temperature_comfort": { "name": "Comfort" },
-      "room_temperature_comfort_plus": { "name": "Comfort+" },
-      "room_temperature_comfort_minus": { "name": "Comfort−" }
+      "room_temperature_economy": {
+        "name": "Eco"
+      },
+      "room_temperature_comfort": {
+        "name": "Comfort"
+      },
+      "room_temperature_comfort_plus": {
+        "name": "Comfort+"
+      },
+      "room_temperature_comfort_minus": {
+        "name": "Comfort\u2212"
+      }
     },
     "water_heater": {
-      "dhw": { "name": "Domestic Hot Water" }
+      "dhw": {
+        "name": "Domestic Hot Water"
+      }
     },
     "climate": {
       "heater": {
@@ -138,7 +159,17 @@
           }
         }
       }
+    },
+    "select": {
+      "boiler_max_power": {
+        "name": "Max boiler power",
+        "state": {
+          "kw_2": "2 kW",
+          "kw_4": "4 kW",
+          "kw_6": "6 kW",
+          "kw_8": "8 kW"
+        }
+      }
     }
   }
 }
-

--- a/custom_components/kospel/strings.json
+++ b/custom_components/kospel/strings.json
@@ -85,10 +85,6 @@
   },
   "entity": {
     "sensor": {
-      "room_temperature_economy": { "name": "Room Temp. Economy" },
-      "room_temperature_comfort": { "name": "Room Temp. Comfort" },
-      "room_temperature_comfort_plus": { "name": "Room Temp. Comfort Plus" },
-      "room_temperature_comfort_minus": { "name": "Room Temp. Comfort Minus" },
       "room_setpoint": { "name": "Room Setpoint" },
       "supply_setpoint": { "name": "DHW Setpoint" },
       "pressure": { "name": "Pressure" },
@@ -116,6 +112,12 @@
           "CO": "CO"
         }
       }
+    },
+    "number": {
+      "room_temperature_economy": { "name": "Eco" },
+      "room_temperature_comfort": { "name": "Comfort" },
+      "room_temperature_comfort_plus": { "name": "Comfort+" },
+      "room_temperature_comfort_minus": { "name": "Comfort−" }
     },
     "water_heater": {
       "dhw": { "name": "Domestic Hot Water" }

--- a/custom_components/kospel/translations/pl.json
+++ b/custom_components/kospel/translations/pl.json
@@ -6,24 +6,32 @@
   },
   "entity": {
     "sensor": {
-      "room_setpoint": { "name": "Nastawa pokojowa" },
-      "supply_setpoint": { "name": "Nastawa CWU" },
-      "pressure": { "name": "Ciśnienie" },
-      "power": { "name": "Moc" },
+      "room_setpoint": {
+        "name": "Nastawa pokojowa"
+      },
+      "supply_setpoint": {
+        "name": "Nastawa CWU"
+      },
+      "pressure": {
+        "name": "Ci\u015bnienie"
+      },
+      "power": {
+        "name": "Moc"
+      },
       "co_heating": {
         "name": "Ogrzewanie CO",
         "state": {
           "running": "Praca",
-          "idle": "Bezczynność",
-          "disabled": "Wyłączone"
+          "idle": "Bezczynno\u015b\u0107",
+          "disabled": "Wy\u0142\u0105czone"
         }
       },
       "cwu_heating": {
         "name": "Ogrzewanie CWU",
         "state": {
           "running": "Praca",
-          "idle": "Bezczynność",
-          "disabled": "Wyłączone"
+          "idle": "Bezczynno\u015b\u0107",
+          "disabled": "Wy\u0142\u0105czone"
         }
       },
       "valve_position": {
@@ -32,16 +40,29 @@
           "DHW": "CWU",
           "CO": "CO"
         }
+      },
+      "max_power_limit": {
+        "name": "Limit mocy"
       }
     },
     "number": {
-      "room_temperature_economy": { "name": "Eko" },
-      "room_temperature_comfort": { "name": "Komfort" },
-      "room_temperature_comfort_plus": { "name": "Komfort+" },
-      "room_temperature_comfort_minus": { "name": "Komfort−" }
+      "room_temperature_economy": {
+        "name": "Eko"
+      },
+      "room_temperature_comfort": {
+        "name": "Komfort"
+      },
+      "room_temperature_comfort_plus": {
+        "name": "Komfort+"
+      },
+      "room_temperature_comfort_minus": {
+        "name": "Komfort\u2212"
+      }
     },
     "water_heater": {
-      "dhw": { "name": "Ciepła woda użytkowa" }
+      "dhw": {
+        "name": "Ciep\u0142a woda u\u017cytkowa"
+      }
     },
     "climate": {
       "heater": {
@@ -49,14 +70,25 @@
         "state_attributes": {
           "preset_mode": {
             "state": {
-              "off": "Wyłączony",
+              "off": "Wy\u0142\u0105czony",
               "summer": "Lato",
               "winter": "Zima",
               "party": "Impreza",
               "vacation": "Wakacje",
-              "manual": "Ręczny"
+              "manual": "R\u0119czny"
             }
           }
+        }
+      }
+    },
+    "select": {
+      "boiler_max_power": {
+        "name": "Maks. moc kot\u0142a",
+        "state": {
+          "kw_2": "2 kW",
+          "kw_4": "4 kW",
+          "kw_6": "6 kW",
+          "kw_8": "8 kW"
         }
       }
     }

--- a/custom_components/kospel/translations/pl.json
+++ b/custom_components/kospel/translations/pl.json
@@ -6,10 +6,6 @@
   },
   "entity": {
     "sensor": {
-      "room_temperature_economy": { "name": "Temp. pokoju ekonomiczna" },
-      "room_temperature_comfort": { "name": "Temp. pokoju komfort" },
-      "room_temperature_comfort_plus": { "name": "Temp. pokoju komfort plus" },
-      "room_temperature_comfort_minus": { "name": "Temp. pokoju komfort minus" },
       "room_setpoint": { "name": "Nastawa pokojowa" },
       "supply_setpoint": { "name": "Nastawa CWU" },
       "pressure": { "name": "Ciśnienie" },
@@ -37,6 +33,12 @@
           "CO": "CO"
         }
       }
+    },
+    "number": {
+      "room_temperature_economy": { "name": "Eko" },
+      "room_temperature_comfort": { "name": "Komfort" },
+      "room_temperature_comfort_plus": { "name": "Komfort+" },
+      "room_temperature_comfort_minus": { "name": "Komfort−" }
     },
     "water_heater": {
       "dhw": { "name": "Ciepła woda użytkowa" }

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -9,7 +9,7 @@ This project provides a Home Assistant integration for Kospel electric heaters. 
 **Key Characteristics:**
 - Uses `kospel-cmi-lib` for heater API communication
 - Config flow choice: HTTP (real device) or YAML (file-based, for development)
-- Entities: climate, sensors, water heater
+- Entities: climate, number (room preset temperatures), sensors, water heater
 - `uv` for dependency management, `pytest` for testing
 
 ## Home Assistant Integration
@@ -43,6 +43,7 @@ custom_components/kospel/
 ├── config_flow.py      # Configuration UI (HTTP or YAML backend choice)
 ├── coordinator.py      # Data update coordinator
 ├── climate.py          # Climate entity
+├── number.py           # Number entities (room preset temperatures)
 ├── sensor.py           # Sensor entities
 ├── water_heater.py     # Water heater entity
 ├── const.py            # Constants

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -9,7 +9,7 @@ This project provides a Home Assistant integration for Kospel electric heaters. 
 **Key Characteristics:**
 - Uses `kospel-cmi-lib` for heater API communication
 - Config flow choice: HTTP (real device) or YAML (file-based, for development)
-- Entities: climate, number (room preset temperatures), sensors, water heater
+- Entities: climate, number (room preset temperatures, **Configuration**), select (boiler max power, **Configuration**), sensors (including max power limit diagnostic), water heater
 - `uv` for dependency management, `pytest` for testing
 
 ## Home Assistant Integration
@@ -44,6 +44,7 @@ custom_components/kospel/
 ├── coordinator.py      # Data update coordinator
 ├── climate.py          # Climate entity
 ├── number.py           # Number entities (room preset temperatures)
+├── select.py           # Select entities (boiler max power step)
 ├── sensor.py           # Sensor entities
 ├── water_heater.py     # Water heater entity
 ├── const.py            # Constants

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license-files = ["LICENSE*"]
 requires-python = ">=3.11"
 dependencies = [
     "aiohttp>=3.13.3",
-    "kospel-cmi-lib==0.1.0a12",
+    "kospel-cmi-lib==0.1.0a13",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/tests/test_number_entity.py
+++ b/tests/test_number_entity.py
@@ -34,6 +34,9 @@ def _device_info(**kwargs):
 
 
 sys.modules["homeassistant.helpers.entity"].DeviceInfo = _device_info
+_entity_cat = MagicMock()
+_entity_cat.CONFIG = "config"
+sys.modules["homeassistant.helpers.entity"].EntityCategory = _entity_cat
 
 
 class _CoordinatorEntityBase:
@@ -154,6 +157,16 @@ class TestKospelRoomPresetNumberEntity:
         assert entity.native_min_value == ROOM_PRESET_TEMP_MIN == 10.0
         assert entity.native_max_value == ROOM_PRESET_TEMP_MAX == 25.0
         assert entity.native_step == ROOM_PRESET_TEMP_STEP == 0.1
+
+    def test_entity_category_is_config(self, mock_coordinator, mock_entry) -> None:
+        """Room presets appear under device Configuration (with max boiler power)."""
+        entity = KospelRoomPresetNumberEntity(
+            mock_coordinator,
+            mock_entry,
+            "room_temperature_economy",
+            "set_room_temperature_economy",
+        )
+        assert entity._attr_entity_category == "config"
 
     @pytest.mark.asyncio
     async def test_async_set_native_value_calls_setter_and_refreshes(

--- a/tests/test_number_entity.py
+++ b/tests/test_number_entity.py
@@ -1,0 +1,223 @@
+"""Tests for Kospel room preset number entities."""
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Mock homeassistant before importing integration modules.
+class _HAModule:
+    __path__ = []
+    __file__ = ""
+    __name__ = "homeassistant"
+    __spec__ = None
+
+
+_ha = _HAModule()
+sys.modules["homeassistant"] = _ha
+sys.modules["homeassistant.config_entries"] = MagicMock()
+sys.modules["homeassistant.components"] = MagicMock()
+const_mock = MagicMock()
+const_mock.UnitOfTemperature = MagicMock()
+const_mock.UnitOfTemperature.CELSIUS = "°C"
+sys.modules["homeassistant.const"] = const_mock
+sys.modules["homeassistant.core"] = MagicMock()
+sys.modules["homeassistant.exceptions"] = MagicMock()
+sys.modules["homeassistant.helpers"] = MagicMock()
+sys.modules["homeassistant.helpers.entity"] = MagicMock()
+sys.modules["homeassistant.helpers.entity_platform"] = MagicMock()
+sys.modules["homeassistant.helpers.update_coordinator"] = MagicMock()
+
+
+def _device_info(**kwargs):
+    return kwargs
+
+
+sys.modules["homeassistant.helpers.entity"].DeviceInfo = _device_info
+
+
+class _CoordinatorEntityBase:
+    """Minimal CoordinatorEntity stand-in for testing."""
+
+    def __init__(self, coordinator):
+        self.coordinator = coordinator
+
+    def async_write_ha_state(self) -> None:
+        """No-op: real HA schedules state write."""
+
+    @classmethod
+    def __class_getitem__(cls, item):
+        return cls
+
+
+class _NumberEntityBase:
+    """Minimal NumberEntity stand-in for testing."""
+
+    @property
+    def native_min_value(self) -> float:
+        """Mirror HA NumberEntity: read from _attr_native_min_value."""
+        return self._attr_native_min_value
+
+    @property
+    def native_max_value(self) -> float:
+        """Mirror HA NumberEntity: read from _attr_native_max_value."""
+        return self._attr_native_max_value
+
+    @property
+    def native_step(self) -> float:
+        """Mirror HA NumberEntity: read from _attr_native_step."""
+        return self._attr_native_step
+
+
+number_mock = MagicMock()
+number_mock.NumberEntity = _NumberEntityBase
+number_mock.NumberDeviceClass = MagicMock()
+number_mock.NumberDeviceClass.TEMPERATURE = "temperature"
+sys.modules["homeassistant.components.number"] = number_mock
+
+sys.modules["homeassistant.helpers.update_coordinator"].CoordinatorEntity = (
+    _CoordinatorEntityBase
+)
+
+from custom_components.kospel.number import (  # noqa: E402
+    KospelRoomPresetNumberEntity,
+    ROOM_PRESET_TEMP_MAX,
+    ROOM_PRESET_TEMP_MIN,
+    ROOM_PRESET_TEMP_STEP,
+)
+
+
+@pytest.fixture
+def mock_entry():
+    """Config entry with stable entry_id for unique_id."""
+    entry = MagicMock()
+    entry.data = {}
+    entry.entry_id = "test-entry-id"
+    entry.options = {}
+    return entry
+
+
+@pytest.fixture
+def mock_coordinator(mock_entry):
+    """Mock coordinator with configurable controller data."""
+    coordinator = MagicMock()
+    coordinator.entry = mock_entry
+    coordinator.last_update_success = True
+    return coordinator
+
+
+class TestKospelRoomPresetNumberEntity:
+    """Tests for native value, bounds, and async_set_native_value."""
+
+    def test_native_value_reads_controller_property(
+        self, mock_coordinator, mock_entry
+    ) -> None:
+        """native_value returns the Ekco_M3 property matching translation_key."""
+        mock_controller = MagicMock()
+        mock_controller.room_temperature_economy = 20.5
+        mock_coordinator.data = mock_controller
+
+        entity = KospelRoomPresetNumberEntity(
+            mock_coordinator,
+            mock_entry,
+            "room_temperature_economy",
+            "set_room_temperature_economy",
+        )
+
+        assert entity.native_value == 20.5
+
+    def test_native_value_returns_none_when_property_missing(
+        self, mock_coordinator, mock_entry
+    ) -> None:
+        """native_value returns None when controller has no such attribute."""
+        mock_controller = object()
+        mock_coordinator.data = mock_controller
+
+        entity = KospelRoomPresetNumberEntity(
+            mock_coordinator,
+            mock_entry,
+            "room_temperature_economy",
+            "set_room_temperature_economy",
+        )
+
+        assert entity.native_value is None
+
+    def test_temperature_bounds_and_step(self, mock_coordinator, mock_entry) -> None:
+        """Entity exposes 10–25 °C range and 0.1 step (matches module constants)."""
+        entity = KospelRoomPresetNumberEntity(
+            mock_coordinator,
+            mock_entry,
+            "room_temperature_comfort",
+            "set_room_temperature_comfort",
+        )
+
+        assert entity.native_min_value == ROOM_PRESET_TEMP_MIN == 10.0
+        assert entity.native_max_value == ROOM_PRESET_TEMP_MAX == 25.0
+        assert entity.native_step == ROOM_PRESET_TEMP_STEP == 0.1
+
+    @pytest.mark.asyncio
+    async def test_async_set_native_value_calls_setter_and_refreshes(
+        self, mock_coordinator, mock_entry
+    ) -> None:
+        """Setter on controller is awaited; coordinator refresh runs after delay."""
+        mock_controller = MagicMock()
+        mock_controller.room_temperature_economy = 20.0
+        mock_controller.set_room_temperature_economy = AsyncMock(return_value=True)
+        mock_coordinator.data = mock_controller
+        mock_coordinator.async_request_refresh = AsyncMock()
+
+        entity = KospelRoomPresetNumberEntity(
+            mock_coordinator,
+            mock_entry,
+            "room_temperature_economy",
+            "set_room_temperature_economy",
+        )
+
+        with patch(
+            "custom_components.kospel.number.asyncio.sleep", new_callable=AsyncMock
+        ):
+            await entity.async_set_native_value(21.5)
+
+        mock_controller.set_room_temperature_economy.assert_awaited_once_with(21.5)
+        mock_coordinator.async_request_refresh.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("translation_key", "setter_name"),
+        [
+            ("room_temperature_economy", "set_room_temperature_economy"),
+            ("room_temperature_comfort", "set_room_temperature_comfort"),
+            ("room_temperature_comfort_plus", "set_room_temperature_comfort_plus"),
+            ("room_temperature_comfort_minus", "set_room_temperature_comfort_minus"),
+        ],
+    )
+    async def test_each_preset_uses_matching_setter(
+        self,
+        mock_coordinator,
+        mock_entry,
+        translation_key: str,
+        setter_name: str,
+    ) -> None:
+        """Each preset entity calls its corresponding Ekco_M3 setter."""
+        mock_controller = MagicMock()
+        for _key, _setter in [
+            ("room_temperature_economy", "set_room_temperature_economy"),
+            ("room_temperature_comfort", "set_room_temperature_comfort"),
+            ("room_temperature_comfort_plus", "set_room_temperature_comfort_plus"),
+            ("room_temperature_comfort_minus", "set_room_temperature_comfort_minus"),
+        ]:
+            setattr(mock_controller, _setter, AsyncMock(return_value=True))
+        mock_coordinator.data = mock_controller
+        mock_coordinator.async_request_refresh = AsyncMock()
+
+        entity = KospelRoomPresetNumberEntity(
+            mock_coordinator, mock_entry, translation_key, setter_name
+        )
+
+        with patch(
+            "custom_components.kospel.number.asyncio.sleep", new_callable=AsyncMock
+        ):
+            await entity.async_set_native_value(22.0)
+
+        called = getattr(mock_controller, setter_name)
+        called.assert_awaited_once_with(22.0)

--- a/tests/test_select_entity.py
+++ b/tests/test_select_entity.py
@@ -1,0 +1,152 @@
+"""Tests for Kospel boiler max power select entity."""
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kospel_cmi.registers.enums import BoilerMaxPowerIndex
+
+# Mock homeassistant before importing integration modules.
+class _HAModule:
+    __path__ = []
+    __file__ = ""
+    __name__ = "homeassistant"
+    __spec__ = None
+
+
+_ha = _HAModule()
+sys.modules["homeassistant"] = _ha
+sys.modules["homeassistant.config_entries"] = MagicMock()
+sys.modules["homeassistant.components"] = MagicMock()
+sys.modules["homeassistant.core"] = MagicMock()
+sys.modules["homeassistant.exceptions"] = MagicMock()
+sys.modules["homeassistant.helpers"] = MagicMock()
+sys.modules["homeassistant.helpers.entity"] = MagicMock()
+entity_mod = sys.modules["homeassistant.helpers.entity"]
+entity_mod.EntityCategory = MagicMock()
+entity_mod.EntityCategory.CONFIG = "config"
+entity_mod.DeviceInfo = lambda **kwargs: kwargs
+sys.modules["homeassistant.helpers.entity_platform"] = MagicMock()
+sys.modules["homeassistant.helpers.update_coordinator"] = MagicMock()
+
+
+class _CoordinatorEntityBase:
+    """Minimal CoordinatorEntity stand-in for testing."""
+
+    def __init__(self, coordinator):
+        self.coordinator = coordinator
+
+    def async_write_ha_state(self) -> None:
+        """No-op: real HA schedules state write."""
+
+    @classmethod
+    def __class_getitem__(cls, item):
+        return cls
+
+
+class _SelectEntityBase:
+    """Minimal SelectEntity stand-in for testing."""
+
+    @property
+    def options(self) -> list[str]:
+        """Mirror HA SelectEntity."""
+        return self._attr_options
+
+
+select_mock = MagicMock()
+select_mock.SelectEntity = _SelectEntityBase
+sys.modules["homeassistant.components.select"] = select_mock
+
+sys.modules["homeassistant.helpers.update_coordinator"].CoordinatorEntity = (
+    _CoordinatorEntityBase
+)
+
+from custom_components.kospel.select import (  # noqa: E402
+    KospelBoilerMaxPowerSelectEntity,
+)
+
+
+@pytest.fixture
+def mock_entry():
+    """Config entry with stable entry_id for unique_id."""
+    entry = MagicMock()
+    entry.data = {}
+    entry.entry_id = "test-entry-id"
+    entry.options = {}
+    return entry
+
+
+@pytest.fixture
+def mock_coordinator(mock_entry):
+    """Mock coordinator with configurable controller data."""
+    coordinator = MagicMock()
+    coordinator.entry = mock_entry
+    coordinator.last_update_success = True
+    return coordinator
+
+
+class TestKospelBoilerMaxPowerSelectEntity:
+    """Tests for options, current_option, and async_select_option."""
+
+    def test_options_order_and_slugs(self, mock_coordinator, mock_entry) -> None:
+        """Entity exposes four options in index order 0..3."""
+        entity = KospelBoilerMaxPowerSelectEntity(mock_coordinator, mock_entry)
+        assert entity.options == ["kw_2", "kw_4", "kw_6", "kw_8"]
+
+    def test_current_option_maps_enum(
+        self, mock_coordinator, mock_entry
+    ) -> None:
+        """current_option returns slug for controller.boiler_max_power_index."""
+        mock_controller = MagicMock()
+        mock_controller.boiler_max_power_index = BoilerMaxPowerIndex.KW_6
+        mock_coordinator.data = mock_controller
+
+        entity = KospelBoilerMaxPowerSelectEntity(mock_coordinator, mock_entry)
+        assert entity.current_option == "kw_6"
+
+    def test_current_option_none_when_unknown(
+        self, mock_coordinator, mock_entry
+    ) -> None:
+        """current_option is None when library reports unknown index."""
+        mock_controller = MagicMock()
+        mock_controller.boiler_max_power_index = None
+        mock_coordinator.data = mock_controller
+
+        entity = KospelBoilerMaxPowerSelectEntity(mock_coordinator, mock_entry)
+        assert entity.current_option is None
+
+    @pytest.mark.asyncio
+    async def test_async_select_option_calls_setter_and_refreshes(
+        self, mock_coordinator, mock_entry
+    ) -> None:
+        """set_boiler_max_power_index is awaited; coordinator refresh runs."""
+        mock_controller = MagicMock()
+        mock_controller.set_boiler_max_power_index = AsyncMock(return_value=True)
+        mock_coordinator.data = mock_controller
+        mock_coordinator.async_request_refresh = AsyncMock()
+
+        entity = KospelBoilerMaxPowerSelectEntity(mock_coordinator, mock_entry)
+
+        with patch(
+            "custom_components.kospel.select.asyncio.sleep", new_callable=AsyncMock
+        ):
+            await entity.async_select_option("kw_4")
+
+        mock_controller.set_boiler_max_power_index.assert_awaited_once()
+        call_arg = mock_controller.set_boiler_max_power_index.await_args[0][0]
+        assert call_arg == BoilerMaxPowerIndex.KW_4
+        mock_coordinator.async_request_refresh.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_async_select_option_invalid_raises(
+        self, mock_coordinator, mock_entry
+    ) -> None:
+        """Invalid option string raises ValueError."""
+        mock_controller = MagicMock()
+        mock_coordinator.data = mock_controller
+
+        entity = KospelBoilerMaxPowerSelectEntity(mock_coordinator, mock_entry)
+
+        with pytest.raises(ValueError, match="Invalid option"):
+            await entity.async_select_option("not_a_step")

--- a/tests/test_sensor_entity.py
+++ b/tests/test_sensor_entity.py
@@ -22,6 +22,7 @@ const_mock.UnitOfTemperature = MagicMock()
 const_mock.UnitOfTemperature.CELSIUS = "°C"
 const_mock.UnitOfPressure = MagicMock()
 const_mock.UnitOfPower = MagicMock()
+const_mock.UnitOfPower.WATT = "W"
 sys.modules["homeassistant.const"] = const_mock
 sys.modules["homeassistant.core"] = MagicMock()
 sys.modules["homeassistant.exceptions"] = MagicMock()
@@ -36,6 +37,10 @@ def _device_info(**kwargs):
 
 
 sys.modules["homeassistant.helpers.entity"].DeviceInfo = _device_info
+_ec = MagicMock()
+_ec.CONFIG = "config"
+_ec.DIAGNOSTIC = "diagnostic"
+sys.modules["homeassistant.helpers.entity"].EntityCategory = _ec
 
 
 class _CoordinatorEntityBase:
@@ -59,6 +64,7 @@ sensor_mock = MagicMock()
 sensor_mock.SensorEntity = _SensorEntityBase
 sensor_mock.SensorDeviceClass = MagicMock()
 sensor_mock.SensorDeviceClass.TEMPERATURE = "temperature"
+sensor_mock.SensorDeviceClass.POWER = "power"
 sensor_mock.SensorStateClass = MagicMock()
 sensor_mock.SensorStateClass.MEASUREMENT = "measurement"
 sys.modules["homeassistant.components.sensor"] = sensor_mock
@@ -67,7 +73,10 @@ sys.modules["homeassistant.helpers.update_coordinator"].CoordinatorEntity = (
     _CoordinatorEntityBase
 )
 
-from custom_components.kospel.sensor import KospelTemperatureSensor
+from custom_components.kospel.sensor import (  # noqa: E402
+    KospelMaxPowerLimitSensor,
+    KospelTemperatureSensor,
+)
 
 
 @pytest.fixture
@@ -122,4 +131,30 @@ class TestKospelTemperatureSensorNativeValue:
             lambda c, name="room_setpoint": getattr(c, name, None),
         )
 
+        assert entity.native_value is None
+
+
+class TestKospelMaxPowerLimitSensorNativeValue:
+    """Tests for max power limit sensor (kW to W)."""
+
+    def test_native_value_converts_kw_to_w(
+        self, mock_coordinator, mock_entry
+    ) -> None:
+        """native_value is boiler_max_power_kw * 1000."""
+        mock_controller = MagicMock()
+        mock_controller.boiler_max_power_kw = 4.0
+        mock_coordinator.data = mock_controller
+
+        entity = KospelMaxPowerLimitSensor(mock_coordinator, mock_entry)
+        assert entity.native_value == 4000.0
+
+    def test_native_value_none_when_missing(
+        self, mock_coordinator, mock_entry
+    ) -> None:
+        """native_value is None when boiler_max_power_kw is None."""
+        mock_controller = MagicMock()
+        mock_controller.boiler_max_power_kw = None
+        mock_coordinator.data = mock_controller
+
+        entity = KospelMaxPowerLimitSensor(mock_coordinator, mock_entry)
         assert entity.native_value is None

--- a/uv.lock
+++ b/uv.lock
@@ -397,7 +397,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.3" },
-    { name = "kospel-cmi-lib", specifier = "==0.1.0a12" },
+    { name = "kospel-cmi-lib", specifier = "==0.1.0a13" },
 ]
 
 [package.metadata.requires-dev]
@@ -433,7 +433,7 @@ wheels = [
 
 [[package]]
 name = "kospel-cmi-lib"
-version = "0.1.0a12"
+version = "0.1.0a13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -441,9 +441,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/e1/4d58e7ef725518ff912782efc29fc9d7f2fed5fb0a5a1250aad2da3eb6a9/kospel_cmi_lib-0.1.0a12.tar.gz", hash = "sha256:998bfe414d79f6df1d9d3c8c623d56ddeb657001ee24fb170ef4c5eccaf8288c", size = 32140, upload-time = "2026-03-22T14:11:51.312Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/66/89dd200caee04c4290e5e33d9b5eefb9c0878d1e38f76a293e82eb2ff52d/kospel_cmi_lib-0.1.0a13.tar.gz", hash = "sha256:12d099546b1f591705b24006e72cd5ff34aed5b7ab887e1a506cbe54491cffcf", size = 32777, upload-time = "2026-03-29T11:43:15.345Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/c6/81ff71e38e38f0e219d9341ee351c0a6fb297864f63b9c09175f6eff58b1/kospel_cmi_lib-0.1.0a12-py3-none-any.whl", hash = "sha256:9c0cd3da0383ef62b5679a48c357e805fae46f6a7afc14d24dd49f47688590de", size = 44102, upload-time = "2026-03-22T14:11:49.736Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e2/51f63528a3ea5b0def7904bba14b9c4505a24ac61daa9b161ca0cb278d55/kospel_cmi_lib-0.1.0a13-py3-none-any.whl", hash = "sha256:87fc287fe8cd619342031f10399f74cd10328221fd549a29bb2edf5ad8fe7444", size = 44691, upload-time = "2026-03-29T11:43:14.2Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Room preset numbers, boiler max power select, and max-power diagnostic

## Summary

This branch exposes room preset temperatures as **writable number** entities, adds a **select** entity for boiler maximum power (2–8 kW steps), and replaces the old read-only room-preset **sensors** with that model. A new **diagnostic** sensor shows the configured max power limit in watts. The integration depends on **kospel-cmi-lib 0.1.0a13** for the underlying register API and setters.

## Motivation

Room economy/comfort setpoints are configuration-style values: they belong next to other system limits (such as max boiler power) and should be adjustable from Home Assistant without treating them as passive “measurement” sensors. Boiler max power is a discrete register choice; a select entity matches the device semantics. The diagnostic sensor gives visibility into the effective kW limit (in W) while keeping the user-facing control on the CONFIG select, in line with Home Assistant entity category rules.

## Changes

### New platforms

- **`number`**: Four entities (`room_temperature_economy`, `room_temperature_comfort`, `room_temperature_comfort_plus`, `room_temperature_comfort_minus`) with temperature device class, 10–25 °C range, 0.1 °C step, **CONFIG** category. Writes call the corresponding `Ekco_M3` async setters, then honor the configured post-write refresh delay and request a coordinator refresh.
- **`select`**: One entity for **boiler max power** with stable options `kw_2` … `kw_8` mapped to `BoilerMaxPowerIndex`, **CONFIG** category, register `0b62` behavior as documented in code.

### Sensors

- Removed the four room-preset temperature sensors (replaced by number entities).
- Added **`max_power_limit`**: power device class, watts, **DIAGNOSTIC** category (CONFIG is not valid for sensors); value derived from `boiler_max_power_kw` × 1000.

### Integration wiring

- `PLATFORMS` in `__init__.py` now includes `number` and `select`.
- **kospel-cmi-lib**: `0.1.0a12` → `0.1.0a13` in `manifest.json`, `pyproject.toml`, and `uv.lock`.

### Localization and docs

- Updated `strings.json` and `translations/pl.json` for new entities and select options.
- `docs/technical.md` adjusted to describe number/select and the max-power diagnostic sensor.

### Tests

- New: `tests/test_number_entity.py`, `tests/test_select_entity.py`.
- Extended: `tests/test_sensor_entity.py` for the new sensor and removed preset sensors.

## How to test

- Reload the integration or restart Home Assistant; confirm four number entities, one max-power select, and the max-power diagnostic sensor appear under the device.
- Change a room preset number and the boiler max power select; verify the device (or YAML backend) reflects values after refresh.
- Run the test suite: `uv run pytest` (or project-standard equivalent).

Fix #26 
Fix #27 