### PR TITLE
Improved error handling

### DIFF
--- a/custom_components/kospel/__init__.py
+++ b/custom_components/kospel/__init__.py
@@ -20,12 +20,19 @@ from .const import (
     get_yaml_state_file_path,
 )
 from .coordinator import KospelDataUpdateCoordinator
-from kospel_cmi.controller.device import Ekco_M3
+from kospel_cmi.controller.device import EkcoM3
 from kospel_cmi.kospel.backend import HttpRegisterBackend, YamlRegisterBackend
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[str] = ["climate", "number", "select", "sensor", "water_heater"]
+PLATFORMS: list[str] = [
+    "binary_sensor",
+    "climate",
+    "number",
+    "select",
+    "sensor",
+    "water_heater",
+]
 
 
 async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
@@ -58,7 +65,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         backend = HttpRegisterBackend(session, api_base_url)
 
     try:
-        heater_controller = Ekco_M3(backend=backend)
+        heater_controller = EkcoM3(backend=backend, strict_refresh=True)
         coordinator = KospelDataUpdateCoordinator(hass, entry, heater_controller)
         hass.data[DOMAIN][entry.entry_id] = coordinator
         await coordinator.async_config_entry_first_refresh()

--- a/custom_components/kospel/binary_sensor.py
+++ b/custom_components/kospel/binary_sensor.py
@@ -1,0 +1,53 @@
+"""Binary sensor entities for Kospel integration (connectivity)."""
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, get_device_info, get_device_identifier
+from .coordinator import KospelDataUpdateCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Kospel binary sensor entities."""
+    coordinator: KospelDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([KospelConnectivityBinarySensor(coordinator, entry)])
+
+
+class KospelConnectivityBinarySensor(
+    CoordinatorEntity[KospelDataUpdateCoordinator], BinarySensorEntity
+):
+    """Hub connectivity: on when communication is OK (debounced failed polls)."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "connectivity"
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+
+    def __init__(
+        self,
+        coordinator: KospelDataUpdateCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the connectivity binary sensor."""
+        super().__init__(coordinator)
+        device_id = get_device_identifier(entry)
+        self._attr_unique_id = f"{device_id}_connectivity"
+        self._attr_device_info = get_device_info(entry)
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True when the heater is reachable within debounce threshold."""
+        return self.coordinator.communication_ok
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self.async_write_ha_state()

--- a/custom_components/kospel/climate.py
+++ b/custom_components/kospel/climate.py
@@ -13,6 +13,7 @@ from homeassistant.components.climate import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -24,8 +25,9 @@ from .const import (
 )
 from .coordinator import KospelDataUpdateCoordinator
 
+from kospel_cmi import KospelError
 from kospel_cmi.registers.enums import HeaterMode, HeatingStatus
-from kospel_cmi.controller.device import Ekco_M3
+from kospel_cmi.controller.device import EkcoM3
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -70,13 +72,13 @@ class KospelClimateEntity(
     @property
     def _heater_mode(self) -> HeaterMode:
         """Current heater mode from the controller."""
-        controller: Ekco_M3 = self.coordinator.data
+        controller: EkcoM3 = self.coordinator.data
         return controller.heater_mode or HeaterMode.OFF
 
     @property
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
-        controller: Ekco_M3 = self.coordinator.data
+        controller: EkcoM3 = self.coordinator.data
         return controller.room_temperature
 
     @property
@@ -92,7 +94,7 @@ class KospelClimateEntity(
     @property
     def target_temperature(self) -> float | None:
         """Return the target temperature (always room_setpoint)."""
-        controller: Ekco_M3 = self.coordinator.data
+        controller: EkcoM3 = self.coordinator.data
         return controller.room_setpoint
 
     @property
@@ -103,7 +105,7 @@ class KospelClimateEntity(
     @property
     def hvac_action(self) -> HVACAction:
         """HVAC action is based on whether CO heating circuit is active."""
-        controller: Ekco_M3 = self.coordinator.data
+        controller: EkcoM3 = self.coordinator.data
         co_status = controller.co_heating_status
         return (
             HVACAction.HEATING
@@ -119,7 +121,7 @@ class KospelClimateEntity(
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        return self.coordinator.last_update_success
+        return self.coordinator.communication_ok
 
     async def async_turn_on(self) -> None:
         """Turn heater on (set to HEAT mode)."""
@@ -132,20 +134,30 @@ class KospelClimateEntity(
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target HVAC mode."""
         _LOGGER.debug("Setting HVAC mode to %s", hvac_mode)
-        controller: Ekco_M3 = self.coordinator.data
+        controller: EkcoM3 = self.coordinator.data
 
         mode = HeaterMode.OFF if hvac_mode == HVACMode.OFF else HeaterMode.WINTER
-        await controller.set_heater_mode(mode)
+        try:
+            await controller.set_heater_mode(mode)
+        except KospelError as err:
+            _LOGGER.error("Failed to set heater mode: %s", err)
+            raise HomeAssistantError(f"Failed to set heater mode: {err}") from err
         self.async_write_ha_state()
         await asyncio.sleep(get_refresh_delay_after_set(self.coordinator.entry))
         await self.coordinator.async_request_refresh()
 
     async def async_set_temperature(self, **kwargs: Unpack[_ClimateSetTemperatureKwargs]) -> None:
-        """Set manual heating target; device switches to MANUAL mode (see Ekco_M3.set_manual_heating)."""
-        controller: Ekco_M3 = self.coordinator.data
+        """Set manual heating target; device switches to MANUAL mode (see EkcoM3.set_manual_heating)."""
+        controller: EkcoM3 = self.coordinator.data
         temperature = kwargs.get("temperature")
         if temperature is not None:
-            await controller.set_manual_heating(temperature)
+            try:
+                await controller.set_manual_heating(temperature)
+            except KospelError as err:
+                _LOGGER.error("Failed to set manual heating: %s", err)
+                raise HomeAssistantError(
+                    f"Failed to set manual heating: {err}"
+                ) from err
             self.async_write_ha_state()
             await asyncio.sleep(get_refresh_delay_after_set(self.coordinator.entry))
             await self.coordinator.async_request_refresh()
@@ -153,8 +165,12 @@ class KospelClimateEntity(
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         _LOGGER.debug("Setting preset mode to %s", preset_mode)
-        controller: Ekco_M3 = self.coordinator.data
-        await controller.set_heater_mode(HeaterMode(preset_mode.lower()))
+        controller: EkcoM3 = self.coordinator.data
+        try:
+            await controller.set_heater_mode(HeaterMode(preset_mode.lower()))
+        except KospelError as err:
+            _LOGGER.error("Failed to set preset mode: %s", err)
+            raise HomeAssistantError(f"Failed to set preset mode: {err}") from err
         self.async_write_ha_state()
         await asyncio.sleep(get_refresh_delay_after_set(self.coordinator.entry))
         await self.coordinator.async_request_refresh()

--- a/custom_components/kospel/const.py
+++ b/custom_components/kospel/const.py
@@ -1,5 +1,6 @@
 """Constants for the Kospel integration."""
 
+import math
 from datetime import timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
@@ -35,6 +36,11 @@ YAML_STATE_FILE_RELATIVE = "data/state.yaml"
 
 # Update intervals
 SCAN_INTERVAL = timedelta(seconds=15)
+
+# Consecutive failed coordinator polls before entities report unavailable (~90s at default scan).
+COMMUNICATION_FAILURE_THRESHOLD = max(
+    1, int(math.ceil(90.0 / SCAN_INTERVAL.total_seconds()))
+)
 
 # Delay before coordinator refresh after set operations (device needs time to persist).
 CONF_REFRESH_DELAY_AFTER_SET = "refresh_delay_after_set"

--- a/custom_components/kospel/coordinator.py
+++ b/custom_components/kospel/coordinator.py
@@ -1,53 +1,92 @@
 """DataUpdateCoordinator for Kospel integration."""
 
+from __future__ import annotations
+
 import logging
 
-from kospel_cmi.controller.device import Ekco_M3
+from kospel_cmi import (
+    IncompleteRegisterRefreshError,
+    KospelConnectionError,
+    KospelError,
+    RegisterReadError,
+)
+from kospel_cmi.controller.device import EkcoM3
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DOMAIN, SCAN_INTERVAL
+from .const import COMMUNICATION_FAILURE_THRESHOLD, DOMAIN, SCAN_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class KospelDataUpdateCoordinator(DataUpdateCoordinator[Ekco_M3]):
+class KospelDataUpdateCoordinator(DataUpdateCoordinator[EkcoM3]):
     """Class to manage fetching data from the Kospel heater."""
 
     def __init__(
         self,
         hass: HomeAssistant,
         entry: ConfigEntry,
-        heater_controller: Ekco_M3,
+        heater_controller: EkcoM3,
     ) -> None:
         """Initialize the coordinator.
 
         Args:
             hass: Home Assistant instance.
             entry: Config entry for this integration.
-            heater_controller: Ekco_M3 device (backed by HTTP or YAML backend).
+            heater_controller: EkcoM3 device (backed by HTTP or YAML backend).
         """
         super().__init__(
             hass,
             _LOGGER,
+            config_entry=entry,
             name=DOMAIN,
             update_interval=SCAN_INTERVAL,
             always_update=True,
         )
         self.entry = entry
         self.heater_controller = heater_controller
+        self._failure_streak: int = 0
 
-    async def _async_update_data(self) -> Ekco_M3:
+    @property
+    def communication_ok(self) -> bool:
+        """True if communication is OK (debounced; see ``COMMUNICATION_FAILURE_THRESHOLD``)."""
+        return self._failure_streak < COMMUNICATION_FAILURE_THRESHOLD
+
+    @callback
+    def _async_refresh_finished(self) -> None:
+        """Track consecutive failures for debounced availability."""
+        if self.last_update_success:
+            self._failure_streak = 0
+        else:
+            self._failure_streak += 1
+
+    async def _async_update_data(self) -> EkcoM3:
         """Fetch data from the heater controller.
 
+        Uses the library strict refresh (see ``EkcoM3(..., strict_refresh=True)``):
+        incomplete batches raise ``IncompleteRegisterRefreshError`` without mutating cache.
+
         Returns:
-            Ekco_M3 instance (entities access settings via coordinator.data).
+            EkcoM3 instance (entities access settings via coordinator.data).
+
+        Raises:
+            UpdateFailed: On transport/read errors or incomplete strict refresh.
         """
         try:
             await self.heater_controller.refresh()
-            return self.heater_controller
-        except Exception as err:
-            _LOGGER.error("Error fetching heater data: %s", err)
+        except IncompleteRegisterRefreshError as err:
+            _LOGGER.warning(
+                "Incomplete heater register batch (strict): missing %s",
+                ", ".join(sorted(err.missing_registers)),
+            )
+            raise UpdateFailed(f"Incomplete heater data: {err}") from err
+        except (KospelConnectionError, RegisterReadError) as err:
+            _LOGGER.debug("Heater read failed: %s", err, exc_info=True)
             raise UpdateFailed(f"Error communicating with heater: {err}") from err
+        except KospelError as err:
+            _LOGGER.error("Unexpected Kospel error during refresh: %s", err)
+            raise UpdateFailed(f"Error communicating with heater: {err}") from err
+
+        return self.heater_controller

--- a/custom_components/kospel/manifest.json
+++ b/custom_components/kospel/manifest.json
@@ -8,7 +8,7 @@
   "dependencies": ["http", "network"],
   "requirements": [
     "aiohttp>=3.13.3",
-    "kospel-cmi-lib==0.1.0a13"
+    "kospel-cmi-lib==1.0.0b1"
   ],
   "codeowners": ["@JanKrl"],
   "integration_type": "hub",

--- a/custom_components/kospel/number.py
+++ b/custom_components/kospel/number.py
@@ -1,25 +1,30 @@
 """Number entities for Kospel integration (room preset temperatures)."""
 
 import asyncio
+import logging
 
 from homeassistant.components.number import NumberDeviceClass, NumberEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from kospel_cmi.controller.device import Ekco_M3
+from kospel_cmi import KospelError
+from kospel_cmi.controller.device import EkcoM3
 
 from .const import DOMAIN, get_device_info, get_device_identifier, get_refresh_delay_after_set
 from .coordinator import KospelDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
 
 ROOM_PRESET_TEMP_MIN = 10.0
 ROOM_PRESET_TEMP_MAX = 25.0
 ROOM_PRESET_TEMP_STEP = 0.1
 
-# (translation_key / unique_id suffix / Ekco_M3 property name, async setter name)
+# (translation_key / unique_id suffix / EkcoM3 property name, async setter name)
 _ROOM_PRESET_ENTITIES: list[tuple[str, str]] = [
     ("room_temperature_economy", "set_room_temperature_economy"),
     ("room_temperature_comfort", "set_room_temperature_comfort"),
@@ -71,8 +76,8 @@ class KospelRoomPresetNumberEntity(
         Args:
             coordinator: Data update coordinator.
             entry: Config entry (device info and refresh delay options).
-            value_attr: Ekco_M3 property name (same as translation_key / unique suffix).
-            setter_name: Name of the async setter on Ekco_M3 (e.g. set_room_temperature_economy).
+            value_attr: EkcoM3 property name (same as translation_key / unique suffix).
+            setter_name: Name of the async setter on EkcoM3 (e.g. set_room_temperature_economy).
         """
         super().__init__(coordinator)
         device_id = get_device_identifier(entry)
@@ -85,19 +90,25 @@ class KospelRoomPresetNumberEntity(
     @property
     def native_value(self) -> float | None:
         """Return the current preset temperature from the controller."""
-        controller: Ekco_M3 = self.coordinator.data
+        controller: EkcoM3 = self.coordinator.data
         return getattr(controller, self._value_attr, None)
 
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        return self.coordinator.last_update_success
+        return self.coordinator.communication_ok
 
     async def async_set_native_value(self, value: float) -> None:
         """Write preset temperature to the heater and refresh coordinator data."""
-        controller: Ekco_M3 = self.coordinator.data
+        controller: EkcoM3 = self.coordinator.data
         setter = getattr(controller, self._setter_name)
-        await setter(value)
+        try:
+            await setter(value)
+        except KospelError as err:
+            _LOGGER.error("Failed to set %s: %s", self._setter_name, err)
+            raise HomeAssistantError(
+                f"Failed to set room preset ({self._setter_name}): {err}"
+            ) from err
         self.async_write_ha_state()
         await asyncio.sleep(get_refresh_delay_after_set(self.coordinator.entry))
         await self.coordinator.async_request_refresh()

--- a/custom_components/kospel/select.py
+++ b/custom_components/kospel/select.py
@@ -1,19 +1,24 @@
 """Select entities for Kospel integration (boiler max power index)."""
 
 import asyncio
+import logging
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from kospel_cmi.controller.device import Ekco_M3
+from kospel_cmi import KospelError
+from kospel_cmi.controller.device import EkcoM3
 from kospel_cmi.registers.enums import BoilerMaxPowerIndex
 
 from .const import DOMAIN, get_device_info, get_device_identifier, get_refresh_delay_after_set
 from .coordinator import KospelDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
 
 # Stable order 0..3 for HA options (do not rely on Enum iteration order).
 _BOILER_MAX_POWER_ORDER: tuple[BoilerMaxPowerIndex, ...] = (
@@ -74,7 +79,7 @@ class KospelBoilerMaxPowerSelectEntity(
     @property
     def current_option(self) -> str | None:
         """Return the selected option slug, or None if the device index is unknown."""
-        controller: Ekco_M3 = self.coordinator.data
+        controller: EkcoM3 = self.coordinator.data
         index = controller.boiler_max_power_index
         if index is None:
             return None
@@ -83,7 +88,7 @@ class KospelBoilerMaxPowerSelectEntity(
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        return self.coordinator.last_update_success
+        return self.coordinator.communication_ok
 
     async def async_select_option(self, option: str) -> None:
         """Write the selected power step to the heater and refresh coordinator data."""
@@ -91,8 +96,14 @@ class KospelBoilerMaxPowerSelectEntity(
         if chosen is None:
             raise ValueError(f"Invalid option: {option}")
 
-        controller: Ekco_M3 = self.coordinator.data
-        await controller.set_boiler_max_power_index(chosen)
+        controller: EkcoM3 = self.coordinator.data
+        try:
+            await controller.set_boiler_max_power_index(chosen)
+        except KospelError as err:
+            _LOGGER.error("Failed to set boiler max power: %s", err)
+            raise HomeAssistantError(
+                f"Failed to set boiler max power: {err}"
+            ) from err
         self.async_write_ha_state()
         await asyncio.sleep(get_refresh_delay_after_set(self.coordinator.entry))
         await self.coordinator.async_request_refresh()

--- a/custom_components/kospel/sensor.py
+++ b/custom_components/kospel/sensor.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN, get_device_info, get_device_identifier
 from .coordinator import KospelDataUpdateCoordinator
 
-from kospel_cmi.controller.device import Ekco_M3
+from kospel_cmi.controller.device import EkcoM3
 
 
 async def async_setup_entry(
@@ -90,7 +90,7 @@ class KospelSensorEntity(CoordinatorEntity[KospelDataUpdateCoordinator], SensorE
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        return self.coordinator.last_update_success
+        return self.coordinator.communication_ok
 
 
 class KospelTemperatureSensor(KospelSensorEntity):
@@ -105,7 +105,7 @@ class KospelTemperatureSensor(KospelSensorEntity):
         coordinator: KospelDataUpdateCoordinator,
         entry: ConfigEntry,
         unique_id_suffix: str,
-        value_getter: Callable[[Ekco_M3], float | None],
+        value_getter: Callable[[EkcoM3], float | None],
     ) -> None:
         """Initialize the temperature sensor."""
         super().__init__(coordinator, entry, unique_id_suffix, unique_id_suffix)
@@ -114,7 +114,7 @@ class KospelTemperatureSensor(KospelSensorEntity):
     @property
     def native_value(self) -> float | None:
         """Return the temperature value."""
-        controller: Ekco_M3 = self.coordinator.data
+        controller: EkcoM3 = self.coordinator.data
         return self._value_getter(controller)
 
     def _handle_coordinator_update(self) -> None:
@@ -140,7 +140,7 @@ class KospelPressureSensor(KospelSensorEntity):
     @property
     def native_value(self) -> float | None:
         """Return the pressure value."""
-        controller: Ekco_M3 = self.coordinator.data
+        controller: EkcoM3 = self.coordinator.data
         return controller.pressure
 
     def _handle_coordinator_update(self) -> None:
@@ -170,7 +170,7 @@ class KospelPowerSensor(KospelSensorEntity):
     @property
     def native_value(self) -> float | None:
         """Return the power value in W (device reports kW)."""
-        controller: Ekco_M3 = self.coordinator.data
+        controller: EkcoM3 = self.coordinator.data
         power_kw = controller.power
         if power_kw is None:
             return None
@@ -205,7 +205,7 @@ class KospelMaxPowerLimitSensor(KospelSensorEntity):
     @property
     def native_value(self) -> float | None:
         """Return the configured max power in W (register 0b34, kW × 1000)."""
-        controller: Ekco_M3 = self.coordinator.data
+        controller: EkcoM3 = self.coordinator.data
         limit_kw = controller.boiler_max_power_kw
         if limit_kw is None:
             return None
@@ -233,7 +233,7 @@ class KospelHeatingStatusSensor(KospelSensorEntity):
     @property
     def native_value(self) -> str | None:
         """Return the heating status (RUNNING, IDLE, DISABLED)."""
-        controller: Ekco_M3 = self.coordinator.data
+        controller: EkcoM3 = self.coordinator.data
         status = getattr(controller, self._setting_name, None)
         if status is None:
             return None
@@ -260,7 +260,7 @@ class KospelValvePositionSensor(KospelSensorEntity):
     @property
     def native_value(self) -> str | None:
         """Return the valve position."""
-        controller: Ekco_M3 = self.coordinator.data
+        controller: EkcoM3 = self.coordinator.data
         position = controller.valve_position
         if position is None:
             return None

--- a/custom_components/kospel/strings.json
+++ b/custom_components/kospel/strings.json
@@ -84,6 +84,11 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "connectivity": {
+        "name": "Connectivity"
+      }
+    },
     "sensor": {
       "room_setpoint": {
         "name": "Room Setpoint"

--- a/custom_components/kospel/translations/pl.json
+++ b/custom_components/kospel/translations/pl.json
@@ -5,6 +5,11 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "connectivity": {
+        "name": "Łączność"
+      }
+    },
     "sensor": {
       "room_setpoint": {
         "name": "Nastawa pokojowa"

--- a/custom_components/kospel/water_heater.py
+++ b/custom_components/kospel/water_heater.py
@@ -14,7 +14,7 @@ from .const import DOMAIN, get_device_info, get_device_identifier
 from .coordinator import KospelDataUpdateCoordinator
 
 from kospel_cmi.registers.enums import CwuMode, WaterHeaterEnabled
-from kospel_cmi.controller.device import Ekco_M3
+from kospel_cmi.controller.device import EkcoM3
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -82,7 +82,7 @@ class KospelWaterHeaterEntity(
         self._attr_unique_id = f"{device_id}_water_heater"
         self._attr_device_info = get_device_info(coordinator.entry)
 
-    def _get_controller(self) -> Ekco_M3:
+    def _get_controller(self) -> EkcoM3:
         """Return the device controller from coordinator data."""
         return self.coordinator.data
 
@@ -128,7 +128,7 @@ class KospelWaterHeaterEntity(
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        return self.coordinator.last_update_success
+        return self.coordinator.communication_ok
 
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,7 +14,7 @@ graph TB
     end
 
     subgraph Library["kospel-cmi-lib (external)"]
-        Ekco_M3[Ekco_M3 device]
+        EkcoM3[EkcoM3 device]
         Backend[Http or YAML backend]
         Registers[registers - decoders encoders enums utils]
     end
@@ -24,12 +24,12 @@ graph TB
     end
 
     HA --> Coordinator
-    Coordinator --> Ekco_M3
-    ClimateEntity --> Ekco_M3
-    SensorEntity --> Ekco_M3
-    WaterHeaterEntity --> Ekco_M3
+    Coordinator --> EkcoM3
+    ClimateEntity --> EkcoM3
+    SensorEntity --> EkcoM3
+    WaterHeaterEntity --> EkcoM3
 
-    Ekco_M3 --> Backend
+    EkcoM3 --> Backend
     Backend --> Registers
     Backend --> HeaterAPI
 ```

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -20,12 +20,12 @@ The integration uses **kospel-cmi-lib** for heater communication. Imports use ab
 
 ```python
 # Correct: Absolute imports from kospel-cmi-lib (installed via manifest requirements)
-from kospel_cmi.controller.device import Ekco_M3
+from kospel_cmi.controller.device import EkcoM3
 from kospel_cmi.kospel.backend import HttpRegisterBackend, YamlRegisterBackend
 from kospel_cmi.registers.enums import HeaterMode
 
-# Device controller: backend only (register map is built into Ekco_M3)
-controller = Ekco_M3(backend=...)
+# Device controller: backend only; strict_refresh ensures full register batch (see library)
+controller = EkcoM3(backend=..., strict_refresh=True)
 
 # Within integration: use relative imports
 from .const import DOMAIN

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license-files = ["LICENSE*"]
 requires-python = ">=3.11"
 dependencies = [
     "aiohttp>=3.13.3",
-    "kospel-cmi-lib==0.1.0a13",
+    "kospel-cmi-lib==1.0.0b1",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock
 
 import aiohttp
 
-from kospel_cmi.controller.device import Ekco_M3
+from kospel_cmi.controller.device import EkcoM3
 from kospel_cmi.kospel.backend import HttpRegisterBackend, YamlRegisterBackend
 
 
@@ -63,6 +63,14 @@ def sample_registers() -> Dict[str, str]:
         "0b67": "c201",
         # Register 0b4a - Water current temperature (420 = 42.0°C)
         "0b4a": "a401",
+        # Register 0b4b - Room temperature (210 = 21.0°C)
+        "0b4b": "d200",
+        # Register 0b46 - Power (0 kW)
+        "0b46": "0000",
+        # Register 0b34 - Max boiler power limit (e.g. 6.0 kW scaled x10)
+        "0b34": "3c00",
+        # Register 0b62 - Boiler max power index
+        "0b62": "0000",
         # Register 0b2f - Supply setpoint CWU (450 = 45.0°C)
         "0b2f": "c201",
         # Register 0b31 - Room setpoint CO (220 = 22.0°C)
@@ -140,10 +148,10 @@ def yaml_backend_state_file(tmp_path: Path) -> Path:
 @pytest.fixture
 async def heater_controller(
     mock_session: AsyncMock, api_base_url: str
-) -> Ekco_M3:
-    """Ekco_M3 instance fixture (HTTP backend)."""
+) -> EkcoM3:
+    """EkcoM3 instance fixture (HTTP backend)."""
     backend = HttpRegisterBackend(mock_session, api_base_url)
-    return Ekco_M3(backend=backend)
+    return EkcoM3(backend=backend)
 
 
 @pytest.fixture
@@ -151,10 +159,10 @@ async def heater_controller_with_registers(
     mock_session: AsyncMock,
     api_base_url: str,
     sample_registers: Dict[str, str],
-) -> Ekco_M3:
-    """Ekco_M3 instance with pre-loaded register data."""
+) -> EkcoM3:
+    """EkcoM3 instance with pre-loaded register data."""
     backend = HttpRegisterBackend(mock_session, api_base_url)
-    controller = Ekco_M3(backend=backend)
+    controller = EkcoM3(backend=backend)
     controller.from_registers(sample_registers)
     return controller
 
@@ -162,7 +170,7 @@ async def heater_controller_with_registers(
 @pytest.fixture
 async def heater_controller_yaml(
     yaml_backend_state_file: Path,
-) -> Ekco_M3:
-    """Ekco_M3 instance with YAML backend (for development/mock tests)."""
+) -> EkcoM3:
+    """EkcoM3 instance with YAML backend (for development/mock tests)."""
     backend = YamlRegisterBackend(state_file=str(yaml_backend_state_file))
-    return Ekco_M3(backend=backend)
+    return EkcoM3(backend=backend)

--- a/tests/integration/test_api_communication.py
+++ b/tests/integration/test_api_communication.py
@@ -5,7 +5,8 @@ from aioresponses import aioresponses
 
 import aiohttp
 
-from kospel_cmi.controller.device import Ekco_M3
+from kospel_cmi import KospelConnectionError, RegisterValueInvalidError
+from kospel_cmi.controller.device import EkcoM3
 from kospel_cmi.kospel.backend import HttpRegisterBackend
 from kospel_cmi.registers.enums import HeaterMode
 
@@ -39,15 +40,14 @@ class TestEndToEndReadWrite:
 
             async with aiohttp.ClientSession() as session:
                 backend = HttpRegisterBackend(session, api_base_url)
-                controller = Ekco_M3(backend=backend)
+                controller = EkcoM3(backend=backend)
 
                 # Refresh from API
                 await controller.refresh()
                 assert controller.heater_mode is not None
 
-                # Modify setting via immediate write
-                result = await controller.set_heater_mode(HeaterMode.WINTER)
-                assert result is True
+                # Modify setting via immediate write (void; raises on failure)
+                await controller.set_heater_mode(HeaterMode.WINTER)
 
                 # Verify changes are reflected
                 assert controller.heater_mode == HeaterMode.WINTER
@@ -70,11 +70,10 @@ class TestEndToEndReadWrite:
 
             async with aiohttp.ClientSession() as session:
                 backend = HttpRegisterBackend(session, api_base_url)
-                controller = Ekco_M3(backend=backend)
+                controller = EkcoM3(backend=backend)
                 await controller.refresh()
 
-                result = await controller.set_heater_mode(HeaterMode.MANUAL)
-                assert result is True
+                await controller.set_heater_mode(HeaterMode.MANUAL)
 
 
 class TestBatchOperations:
@@ -97,7 +96,7 @@ class TestBatchOperations:
 
             async with aiohttp.ClientSession() as session:
                 backend = HttpRegisterBackend(session, api_base_url)
-                controller = Ekco_M3(backend=backend)
+                controller = EkcoM3(backend=backend)
 
                 await controller.refresh()
 
@@ -121,11 +120,10 @@ class TestBatchOperations:
 
             async with aiohttp.ClientSession() as session:
                 backend = HttpRegisterBackend(session, api_base_url)
-                controller = Ekco_M3(backend=backend)
+                controller = EkcoM3(backend=backend)
                 await controller.refresh()
 
-                result = await controller.set_heater_mode(HeaterMode.MANUAL)
-                assert result is True
+                await controller.set_heater_mode(HeaterMode.MANUAL)
 
     @pytest.mark.asyncio
     async def test_set_manual_heating_writes_both_registers(
@@ -147,11 +145,10 @@ class TestBatchOperations:
 
             async with aiohttp.ClientSession() as session:
                 backend = HttpRegisterBackend(session, api_base_url)
-                controller = Ekco_M3(backend=backend)
+                controller = EkcoM3(backend=backend)
                 await controller.refresh()
 
-                result = await controller.set_manual_heating(25.0)
-                assert result is True
+                await controller.set_manual_heating(25.0)
 
 
 class TestErrorRecovery:
@@ -159,25 +156,25 @@ class TestErrorRecovery:
 
     @pytest.mark.asyncio
     async def test_network_error_during_read(self, api_base_url):
-        """Test handling of network error during read."""
+        """Network error during read raises KospelConnectionError; cache unchanged."""
         with aioresponses() as m:
             read_url = f"{api_base_url}/0b00/256"
             m.get(read_url, exception=aiohttp.ClientError("Connection error"))
 
             async with aiohttp.ClientSession() as session:
                 backend = HttpRegisterBackend(session, api_base_url)
-                controller = Ekco_M3(backend=backend)
+                controller = EkcoM3(backend=backend)
 
-                await controller.refresh()
+                with pytest.raises(KospelConnectionError):
+                    await controller.refresh()
 
-                # Library exposes no public signal for empty batch; _registers is empty on API failure.
                 assert len(controller._registers) == 0
 
     @pytest.mark.asyncio
-    async def test_network_error_during_write_returns_false(
+    async def test_network_error_during_write_raises(
         self, api_base_url, sample_registers
     ):
-        """Test that set_heater_mode returns False when write fails."""
+        """Test that set_heater_mode raises when write fails."""
         registers = sample_registers.copy()
 
         with aioresponses() as m:
@@ -189,17 +186,17 @@ class TestErrorRecovery:
 
             async with aiohttp.ClientSession() as session:
                 backend = HttpRegisterBackend(session, api_base_url)
-                controller = Ekco_M3(backend=backend)
+                controller = EkcoM3(backend=backend)
                 await controller.refresh()
 
-                result = await controller.set_heater_mode(HeaterMode.WINTER)
-                assert result is False
+                with pytest.raises(KospelConnectionError):
+                    await controller.set_heater_mode(HeaterMode.WINTER)
 
     @pytest.mark.asyncio
-    async def test_invalid_register_data_handles_gracefully(
+    async def test_invalid_register_data_raises(
         self, api_base_url
     ):
-        """Test handling of invalid register data."""
+        """Invalid hex in batch read raises RegisterValueInvalidError."""
         invalid_registers = {"0b55": "invalid"}
 
         with aioresponses() as m:
@@ -208,17 +205,16 @@ class TestErrorRecovery:
 
             async with aiohttp.ClientSession() as session:
                 backend = HttpRegisterBackend(session, api_base_url)
-                controller = Ekco_M3(backend=backend)
+                controller = EkcoM3(backend=backend)
 
-                await controller.refresh()
-
-                assert controller.heater_mode is None
+                with pytest.raises(RegisterValueInvalidError):
+                    await controller.refresh()
 
     @pytest.mark.asyncio
     async def test_partial_write_failures(
         self, api_base_url, sample_registers
     ):
-        """Test handling of partial write failures in set_manual_heating."""
+        """Partial write failure in set_manual_heating raises KospelConnectionError."""
         registers = sample_registers.copy()
 
         with aioresponses() as m:
@@ -234,11 +230,11 @@ class TestErrorRecovery:
 
             async with aiohttp.ClientSession() as session:
                 backend = HttpRegisterBackend(session, api_base_url)
-                controller = Ekco_M3(backend=backend)
+                controller = EkcoM3(backend=backend)
                 await controller.refresh()
 
-                result = await controller.set_manual_heating(25.0)
-                assert result is False
+                with pytest.raises(KospelConnectionError):
+                    await controller.set_manual_heating(25.0)
 
 
 class TestRegisterCaching:
@@ -260,13 +256,12 @@ class TestRegisterCaching:
 
             async with aiohttp.ClientSession() as session:
                 backend = HttpRegisterBackend(session, api_base_url)
-                controller = Ekco_M3(backend=backend)
+                controller = EkcoM3(backend=backend)
                 await controller.refresh()
 
                 assert "0b55" in controller._registers
 
-                result = await controller.set_heater_mode(HeaterMode.WINTER)
-                assert result is True
+                await controller.set_heater_mode(HeaterMode.WINTER)
 
     @pytest.mark.asyncio
     async def test_cache_invalidated_on_refresh(
@@ -284,7 +279,7 @@ class TestRegisterCaching:
 
             async with aiohttp.ClientSession() as session:
                 backend = HttpRegisterBackend(session, api_base_url)
-                controller = Ekco_M3(backend=backend)
+                controller = EkcoM3(backend=backend)
 
                 await controller.refresh()
                 original_mode = controller.heater_mode
@@ -311,10 +306,9 @@ class TestRegisterCaching:
 
             async with aiohttp.ClientSession() as session:
                 backend = HttpRegisterBackend(session, api_base_url)
-                controller = Ekco_M3(backend=backend)
+                controller = EkcoM3(backend=backend)
                 await controller.refresh()
 
-                result = await controller.set_heater_mode(HeaterMode.WINTER)
-                assert result is True
+                await controller.set_heater_mode(HeaterMode.WINTER)
 
                 assert controller.heater_mode == HeaterMode.WINTER

--- a/tests/integration/test_mock_mode.py
+++ b/tests/integration/test_mock_mode.py
@@ -3,15 +3,15 @@
 import pytest
 import yaml
 
-from kospel_cmi.controller.device import Ekco_M3
+from kospel_cmi.controller.device import EkcoM3
 from kospel_cmi.kospel.backend import YamlRegisterBackend
 from kospel_cmi.registers.enums import HeaterMode
 
 
-def _controller_for_state_file(state_file: str) -> Ekco_M3:
-    """Create Ekco_M3 with YamlRegisterBackend for the given state file."""
+def _controller_for_state_file(state_file: str) -> EkcoM3:
+    """Create EkcoM3 with YamlRegisterBackend for the given state file."""
     backend = YamlRegisterBackend(state_file=state_file)
-    return Ekco_M3(backend=backend)
+    return EkcoM3(backend=backend)
 
 
 class TestYamlBackendFullCycle:
@@ -29,8 +29,7 @@ class TestYamlBackendFullCycle:
 
         assert controller.heater_mode is not None
 
-        result = await controller.set_heater_mode(HeaterMode.MANUAL)
-        assert result is True
+        await controller.set_heater_mode(HeaterMode.MANUAL)
 
         assert state_file.exists()
         with open(state_file, "r") as f:

--- a/tests/integration/test_water_heater_registers.py
+++ b/tests/integration/test_water_heater_registers.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from kospel_cmi.controller.device import Ekco_M3
+from kospel_cmi.controller.device import EkcoM3
 
 
 class TestWaterHeaterRegisters:
@@ -10,7 +10,7 @@ class TestWaterHeaterRegisters:
 
     @pytest.mark.asyncio
     async def test_water_current_temperature_decoded(
-        self, heater_controller_with_registers: Ekco_M3
+        self, heater_controller_with_registers: EkcoM3
     ) -> None:
         """water_current_temperature is decoded from register 0b4a."""
         controller = heater_controller_with_registers
@@ -20,7 +20,7 @@ class TestWaterHeaterRegisters:
 
     @pytest.mark.asyncio
     async def test_pressure_decoded_from_0b4e(
-        self, heater_controller_with_registers: Ekco_M3
+        self, heater_controller_with_registers: EkcoM3
     ) -> None:
         """pressure is decoded from register 0b4e (scaled_x100)."""
         controller = heater_controller_with_registers
@@ -30,7 +30,7 @@ class TestWaterHeaterRegisters:
 
     @pytest.mark.asyncio
     async def test_cwu_temperatures_decoded(
-        self, heater_controller_with_registers: Ekco_M3
+        self, heater_controller_with_registers: EkcoM3
     ) -> None:
         """cwu_temperature_economy and cwu_temperature_comfort are decoded."""
         controller = heater_controller_with_registers
@@ -39,7 +39,7 @@ class TestWaterHeaterRegisters:
 
     @pytest.mark.asyncio
     async def test_supply_setpoint_decoded(
-        self, heater_controller_with_registers: Ekco_M3
+        self, heater_controller_with_registers: EkcoM3
     ) -> None:
         """supply_setpoint (CWU) is decoded from register 0b2f."""
         controller = heater_controller_with_registers
@@ -47,7 +47,7 @@ class TestWaterHeaterRegisters:
 
     @pytest.mark.asyncio
     async def test_room_setpoint_decoded(
-        self, heater_controller_with_registers: Ekco_M3
+        self, heater_controller_with_registers: EkcoM3
     ) -> None:
         """room_setpoint (CO) is decoded from register 0b31."""
         controller = heater_controller_with_registers

--- a/tests/test_climate_entity.py
+++ b/tests/test_climate_entity.py
@@ -94,6 +94,7 @@ def mock_coordinator():
     coordinator.entry.options = {}
     coordinator.entry.entry_id = "test-entry-id"
     coordinator.last_update_success = True
+    coordinator.communication_ok = True
     return coordinator
 
 

--- a/tests/test_kospel_library_contract.py
+++ b/tests/test_kospel_library_contract.py
@@ -1,0 +1,17 @@
+"""Sanity checks against kospel-cmi-lib (no Home Assistant import)."""
+
+import math
+from datetime import timedelta
+
+from kospel_cmi.controller.device import EkcoM3
+
+
+def test_ekco_m3_required_registers_nonempty() -> None:
+    """Library owns the register set for strict refresh."""
+    assert len(EkcoM3.REQUIRED_REGISTERS) > 0
+
+
+def test_communication_threshold_math_matches_plan() -> None:
+    """~90s debounce at 15s scan ≈ 6 failures (matches const.COMMUNICATION_FAILURE_THRESHOLD)."""
+    scan = timedelta(seconds=15)
+    assert max(1, int(math.ceil(90.0 / scan.total_seconds()))) == 6

--- a/tests/test_number_entity.py
+++ b/tests/test_number_entity.py
@@ -106,6 +106,7 @@ def mock_coordinator(mock_entry):
     coordinator = MagicMock()
     coordinator.entry = mock_entry
     coordinator.last_update_success = True
+    coordinator.communication_ok = True
     return coordinator
 
 
@@ -115,7 +116,7 @@ class TestKospelRoomPresetNumberEntity:
     def test_native_value_reads_controller_property(
         self, mock_coordinator, mock_entry
     ) -> None:
-        """native_value returns the Ekco_M3 property matching translation_key."""
+        """native_value returns the EkcoM3 property matching translation_key."""
         mock_controller = MagicMock()
         mock_controller.room_temperature_economy = 20.5
         mock_coordinator.data = mock_controller
@@ -211,7 +212,7 @@ class TestKospelRoomPresetNumberEntity:
         translation_key: str,
         setter_name: str,
     ) -> None:
-        """Each preset entity calls its corresponding Ekco_M3 setter."""
+        """Each preset entity calls its corresponding EkcoM3 setter."""
         mock_controller = MagicMock()
         for _key, _setter in [
             ("room_temperature_economy", "set_room_temperature_economy"),

--- a/tests/test_select_entity.py
+++ b/tests/test_select_entity.py
@@ -83,6 +83,7 @@ def mock_coordinator(mock_entry):
     coordinator = MagicMock()
     coordinator.entry = mock_entry
     coordinator.last_update_success = True
+    coordinator.communication_ok = True
     return coordinator
 
 

--- a/tests/test_sensor_entity.py
+++ b/tests/test_sensor_entity.py
@@ -94,6 +94,7 @@ def mock_coordinator(mock_entry):
     coordinator = MagicMock()
     coordinator.entry = mock_entry
     coordinator.last_update_success = True
+    coordinator.communication_ok = True
     return coordinator
 
 
@@ -103,7 +104,7 @@ class TestKospelTemperatureSensorNativeValue:
     def test_native_value_returns_float_from_controller_attribute(
         self, mock_coordinator, mock_entry
     ) -> None:
-        """native_value returns the float from the bound Ekco_M3 attribute."""
+        """native_value returns the float from the bound EkcoM3 attribute."""
         mock_controller = MagicMock()
         mock_controller.room_setpoint = 22.5
         mock_coordinator.data = mock_controller

--- a/tests/test_water_heater_entity.py
+++ b/tests/test_water_heater_entity.py
@@ -82,6 +82,7 @@ def mock_coordinator():
     coordinator.entry.options = {}
     coordinator.entry.entry_id = "test-entry-id"
     coordinator.last_update_success = True
+    coordinator.communication_ok = True
     return coordinator
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -397,7 +397,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.3" },
-    { name = "kospel-cmi-lib", specifier = "==0.1.0a13" },
+    { name = "kospel-cmi-lib", specifier = "==1.0.0b1" },
 ]
 
 [package.metadata.requires-dev]
@@ -433,7 +433,7 @@ wheels = [
 
 [[package]]
 name = "kospel-cmi-lib"
-version = "0.1.0a13"
+version = "1.0.0b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -441,9 +441,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/20/66/89dd200caee04c4290e5e33d9b5eefb9c0878d1e38f76a293e82eb2ff52d/kospel_cmi_lib-0.1.0a13.tar.gz", hash = "sha256:12d099546b1f591705b24006e72cd5ff34aed5b7ab887e1a506cbe54491cffcf", size = 32777, upload-time = "2026-03-29T11:43:15.345Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/33/250af745c7ce4a79b9aa7eb51dea1063a92fa222f472c447d1b0e0deaa86/kospel_cmi_lib-1.0.0b1.tar.gz", hash = "sha256:da068d711aae1959300ef8667403b3b9ceee95363d4d5caf4db84c293f3fe134", size = 35322, upload-time = "2026-04-12T17:45:42.341Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/e2/51f63528a3ea5b0def7904bba14b9c4505a24ac61daa9b161ca0cb278d55/kospel_cmi_lib-0.1.0a13-py3-none-any.whl", hash = "sha256:87fc287fe8cd619342031f10399f74cd10328221fd549a29bb2edf5ad8fe7444", size = 44691, upload-time = "2026-03-29T11:43:14.2Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f7/ea4c8ecf1380dba072265a7b405a9393e1677f1febbb9c7252376e0e71d3/kospel_cmi_lib-1.0.0b1-py3-none-any.whl", hash = "sha256:b813954c2e58e7deb61ae06cf103d1a7fe25255d80eff1027704ea9b3493363a", size = 47723, upload-time = "2026-04-12T17:45:40.83Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Fix #24: strict register refresh, connectivity debounce

## Summary

Fixes [issue #24](https://github.com/JanKrl/ha-kospel-cmi/issues/24): intermittent failed reads no longer overwrite entity state with zeros. The integration now relies on **kospel-cmi-lib** strict refresh and typed errors, maps them to **`UpdateFailed`**, and only marks entities **unavailable** after **about 90 seconds** of consecutive failed polls. A **connectivity** binary sensor reflects the same debounced communication state.

This branch also carries prior work (selectors / power, hotfixes, lib alignment) merged ahead of `main`; see commit history for detail.

---

## Problem

When the heater HTTP API failed or returned an unusable batch, the library could still complete `refresh()` and replace the in-memory register cache with empty or incomplete data. Missing registers decoded as zero, Home Assistant treated the coordinator update as **successful**, and history showed **spurious drops to zero** while entities stayed **available**.

---

## Solution

1. **kospel-cmi-lib `1.0.0b1`** — Stricter batch reads, `EkcoM3(..., strict_refresh=True)`, and exceptions such as `IncompleteRegisterRefreshError`, `KospelConnectionError`, and `RegisterReadError` instead of silently poisoning the cache.

2. **Coordinator** — After `refresh()`, map library errors to `UpdateFailed` with appropriate logging (warning for incomplete strict refresh, debug for expected read/connection failures).

3. **Debounced availability** — `COMMUNICATION_FAILURE_THRESHOLD` (derived from ~90 s and `SCAN_INTERVAL`) and `_async_refresh_finished` track consecutive failures. **`communication_ok`** is true only while the failure streak is below that threshold.

4. **Entities** — `available` is based on **`coordinator.communication_ok`**, not raw `last_update_success`, so brief glitches do not immediately flip every entity to unavailable.

5. **Connectivity binary sensor** — `device_class: connectivity`, `is_on` mirrors `communication_ok`, so dashboards can show hub reachability explicitly.

---

## Dependency change

| Location | Change |
|----------|--------|
| `custom_components/kospel/manifest.json` | `kospel-cmi-lib==1.0.0b1` |
| `pyproject.toml` / `uv.lock` | Same pin for development installs |

---

## Testing

```bash
uv sync --all-groups
uv run python -m pytest tests/ -v
```

All tests should pass; integration tests were updated for the new library contract (`EkcoM3`, strict refresh, register expectations).