### PR TITLE
Max powere select to be int-string

### DIFF
--- a/custom_components/kospel/select.py
+++ b/custom_components/kospel/select.py
@@ -29,10 +29,10 @@ _BOILER_MAX_POWER_ORDER: tuple[BoilerMaxPowerIndex, ...] = (
 )
 
 _OPTION_FOR_INDEX: dict[BoilerMaxPowerIndex, str] = {
-    BoilerMaxPowerIndex.KW_2: "kw_2",
-    BoilerMaxPowerIndex.KW_4: "kw_4",
-    BoilerMaxPowerIndex.KW_6: "kw_6",
-    BoilerMaxPowerIndex.KW_8: "kw_8",
+    BoilerMaxPowerIndex.KW_2: "2",
+    BoilerMaxPowerIndex.KW_4: "4",
+    BoilerMaxPowerIndex.KW_6: "6",
+    BoilerMaxPowerIndex.KW_8: "8",
 }
 
 _INDEX_FOR_OPTION: dict[str, BoilerMaxPowerIndex] = {
@@ -78,7 +78,7 @@ class KospelBoilerMaxPowerSelectEntity(
 
     @property
     def current_option(self) -> str | None:
-        """Return the selected option slug, or None if the device index is unknown."""
+        """Return the selected kW step as a string (e.g. '4'), or None if unknown."""
         controller: EkcoM3 = self.coordinator.data
         index = controller.boiler_max_power_index
         if index is None:

--- a/custom_components/kospel/strings.json
+++ b/custom_components/kospel/strings.json
@@ -169,10 +169,10 @@
       "boiler_max_power": {
         "name": "Max boiler power",
         "state": {
-          "kw_2": "2 kW",
-          "kw_4": "4 kW",
-          "kw_6": "6 kW",
-          "kw_8": "8 kW"
+          "2": "2 kW",
+          "4": "4 kW",
+          "6": "6 kW",
+          "8": "8 kW"
         }
       }
     }

--- a/custom_components/kospel/translations/pl.json
+++ b/custom_components/kospel/translations/pl.json
@@ -90,10 +90,10 @@
       "boiler_max_power": {
         "name": "Maks. moc kot\u0142a",
         "state": {
-          "kw_2": "2 kW",
-          "kw_4": "4 kW",
-          "kw_6": "6 kW",
-          "kw_8": "8 kW"
+          "2": "2 kW",
+          "4": "4 kW",
+          "6": "6 kW",
+          "8": "8 kW"
         }
       }
     }

--- a/tests/test_select_entity.py
+++ b/tests/test_select_entity.py
@@ -90,21 +90,21 @@ def mock_coordinator(mock_entry):
 class TestKospelBoilerMaxPowerSelectEntity:
     """Tests for options, current_option, and async_select_option."""
 
-    def test_options_order_and_slugs(self, mock_coordinator, mock_entry) -> None:
-        """Entity exposes four options in index order 0..3."""
+    def test_options_order_and_numeric_strings(self, mock_coordinator, mock_entry) -> None:
+        """Entity exposes four kW options in index order 0..3."""
         entity = KospelBoilerMaxPowerSelectEntity(mock_coordinator, mock_entry)
-        assert entity.options == ["kw_2", "kw_4", "kw_6", "kw_8"]
+        assert entity.options == ["2", "4", "6", "8"]
 
     def test_current_option_maps_enum(
         self, mock_coordinator, mock_entry
     ) -> None:
-        """current_option returns slug for controller.boiler_max_power_index."""
+        """current_option returns kW string for controller.boiler_max_power_index."""
         mock_controller = MagicMock()
         mock_controller.boiler_max_power_index = BoilerMaxPowerIndex.KW_6
         mock_coordinator.data = mock_controller
 
         entity = KospelBoilerMaxPowerSelectEntity(mock_coordinator, mock_entry)
-        assert entity.current_option == "kw_6"
+        assert entity.current_option == "6"
 
     def test_current_option_none_when_unknown(
         self, mock_coordinator, mock_entry
@@ -132,7 +132,7 @@ class TestKospelBoilerMaxPowerSelectEntity:
         with patch(
             "custom_components.kospel.select.asyncio.sleep", new_callable=AsyncMock
         ):
-            await entity.async_select_option("kw_4")
+            await entity.async_select_option("4")
 
         mock_controller.set_boiler_max_power_index.assert_awaited_once()
         call_arg = mock_controller.set_boiler_max_power_index.await_args[0][0]


### PR DESCRIPTION
# Fix boiler max power select option values (closes #31)

## Summary

The **Max boiler power** select entity now uses numeric option strings (`2`, `4`, `6`, `8`) instead of internal slugs (`kw_2`, `kw_4`, …). Home Assistant still stores select state as a string, but the value matches the kW step in a straightforward way for automations and developer tools.

## Motivation

See [issue #31](https://github.com/JanKrl/ha-kospel-cmi/issues/31): callers expect values like `4` rather than `kw_4`.

## Changes

- **`custom_components/kospel/select.py`**: Map `BoilerMaxPowerIndex` to `"2"` / `"4"` / `"6"` / `"8"`; library calls (`set_boiler_max_power_index`) are unchanged.
- **`custom_components/kospel/strings.json`** and **`custom_components/kospel/translations/pl.json`**: Align `entity.select.boiler_max_power.state` translation keys with the new option strings (display strings unchanged, e.g. `4 kW`).
- **`tests/test_select_entity.py`**: Update expectations and `async_select_option` argument.

## Breaking change

Automations or scripts that use `select.select_option` with `option: kw_4` (or other `kw_*` values) must be updated to use `option: "4"` (and similarly `"2"`, `"6"`, `"8"`).

## Testing

```bash
uv run python -m pytest tests/ -v
```

All tests pass.
