### PR TITLE
Add current temp sensors + fix translations

### DIFF
--- a/custom_components/kospel/sensor.py
+++ b/custom_components/kospel/sensor.py
@@ -33,6 +33,8 @@ async def async_setup_entry(
     temperature_sensors = [
         ("room_setpoint", "room_setpoint"),
         ("supply_setpoint", "supply_setpoint"),
+        ("room_temperature", "room_temperature"),
+        ("water_temperature", "water_current_temperature"),
     ]
 
     for unique_id_suffix, attr_name in temperature_sensors:

--- a/custom_components/kospel/strings.json
+++ b/custom_components/kospel/strings.json
@@ -96,6 +96,12 @@
       "supply_setpoint": {
         "name": "DHW Setpoint"
       },
+      "room_temperature": {
+        "name": "Room temperature"
+      },
+      "water_temperature": {
+        "name": "Water temperature"
+      },
       "pressure": {
         "name": "Pressure"
       },

--- a/custom_components/kospel/translations/pl.json
+++ b/custom_components/kospel/translations/pl.json
@@ -4,6 +4,85 @@
       "name": "Grzejnik Kospel"
     }
   },
+  "config": {
+    "step": {
+      "user": {
+        "title": "Wybierz typ po\u0142\u0105czenia",
+        "description": "Wybierz spos\u00f3b po\u0142\u0105czenia: HTTP (prawdziwe urz\u0105dzenie) lub plik YAML (rozw\u00f3j). W trybie YAML stan jest zapisywany w {yaml_path}.",
+        "data": {
+          "backend_type": "Typ po\u0142\u0105czenia"
+        },
+        "options": {
+          "option_http": "Grzejnik (HTTP)",
+          "option_yaml": "Plik (rozw\u00f3j)"
+        }
+      },
+      "http_method": {
+        "title": "Spos\u00f3b po\u0142\u0105czenia",
+        "description": "Wykryj urz\u0105dzenia w sieci lub wprowad\u017a dane r\u0119cznie.",
+        "data": {
+          "http_method": "Metoda"
+        },
+        "options": {
+          "option_discover": "Wykryj urz\u0105dzenia",
+          "option_manual": "Wprowad\u017a r\u0119cznie"
+        }
+      },
+      "discover": {
+        "title": "Skanowanie sieci",
+        "description": "Skanowanie urz\u0105dze\u0144 Kospel. Mo\u017ce to potrwa\u0107 do minuty.",
+        "data": {
+          "action": "Akcja"
+        },
+        "options": {
+          "option_retry": "Skanuj ponownie",
+          "option_manual": "Wprowad\u017a r\u0119cznie"
+        }
+      },
+      "select_device": {
+        "title": "Wybierz urz\u0105dzenie",
+        "description": "Wybierz grzejnik Kospel do dodania.",
+        "data": {
+          "device": "Urz\u0105dzenie"
+        }
+      },
+      "http": {
+        "title": "Po\u0142\u0105czenie z grzejnikiem",
+        "description": "Podaj adres IP grzejnika i identyfikator urz\u0105dzenia. Adres URL: http://[IP]/api/dev/[ID].",
+        "data": {
+          "heater_ip": "Adres IP grzejnika",
+          "device_id": "Identyfikator urz\u0105dzenia"
+        }
+      }
+    },
+    "progress": {
+      "discover": {
+        "title": "Skanowanie sieci",
+        "description": "Wyszukiwanie urz\u0105dze\u0144 Kospel w sieci. Mo\u017ce to potrwa\u0107 do minuty."
+      }
+    },
+    "error": {
+      "cannot_connect": "Nie uda\u0142o si\u0119 po\u0142\u0105czy\u0107 z grzejnikiem",
+      "invalid_auth": "Nieprawid\u0142owe uwierzytelnienie",
+      "invalid_device_id": "Identyfikator urz\u0105dzenia musi by\u0107 z zakresu 1\u2013255",
+      "no_devices_found": "Nie znaleziono urz\u0105dze\u0144 Kospel w sieci",
+      "unknown": "Wyst\u0105pi\u0142 nieoczekiwany b\u0142\u0105d"
+    },
+    "abort": {
+      "already_configured": "Integracja jest ju\u017c skonfigurowana"
+    },
+    "options": {
+      "step": {
+        "init": {
+          "title": "Opcje integracji",
+          "description": "Grzejniki Kospel mog\u0105 potrzebowa\u0107 czasu na zapis zmian. Je\u015bli interfejs wraca do poprzedniej warto\u015bci po prze\u0142\u0105czeniu tryb\u00f3w, zwi\u0119ksz to op\u00f3\u017anienie.",
+          "data": {
+            "refresh_delay_after_set": "Op\u00f3\u017anienie od\u015bwie\u017cenia po zmianie (sekundy)"
+          }
+        }
+      }
+    }
+  },
   "entity": {
     "binary_sensor": {
       "connectivity": {
@@ -16,6 +95,12 @@
       },
       "supply_setpoint": {
         "name": "Nastawa CWU"
+      },
+      "room_temperature": {
+        "name": "Temperatura pokoju"
+      },
+      "water_temperature": {
+        "name": "Temperatura wody"
       },
       "pressure": {
         "name": "Ci\u015bnienie"

--- a/tests/test_sensor_entity.py
+++ b/tests/test_sensor_entity.py
@@ -134,6 +134,56 @@ class TestKospelTemperatureSensorNativeValue:
 
         assert entity.native_value is None
 
+    def test_native_value_room_temperature(
+        self, mock_coordinator, mock_entry
+    ) -> None:
+        """native_value reads room_temperature from controller."""
+        mock_controller = MagicMock()
+        mock_controller.room_temperature = 21.0
+        mock_coordinator.data = mock_controller
+
+        entity = KospelTemperatureSensor(
+            mock_coordinator,
+            mock_entry,
+            "room_temperature",
+            lambda c, name="room_temperature": getattr(c, name, None),
+        )
+
+        assert entity.native_value == 21.0
+
+    def test_native_value_water_temperature_reads_water_current_temperature(
+        self, mock_coordinator, mock_entry
+    ) -> None:
+        """Water sensor uses translation id water_temperature; value from water_current_temperature."""
+        mock_controller = MagicMock()
+        mock_controller.water_current_temperature = 42.0
+        mock_coordinator.data = mock_controller
+
+        entity = KospelTemperatureSensor(
+            mock_coordinator,
+            mock_entry,
+            "water_temperature",
+            lambda c, name="water_current_temperature": getattr(c, name, None),
+        )
+
+        assert entity.native_value == 42.0
+
+    def test_native_value_water_temperature_none_when_attr_missing(
+        self, mock_coordinator, mock_entry
+    ) -> None:
+        """Water temperature sensor returns None without water_current_temperature."""
+        mock_controller = object()
+        mock_coordinator.data = mock_controller
+
+        entity = KospelTemperatureSensor(
+            mock_coordinator,
+            mock_entry,
+            "water_temperature",
+            lambda c, name="water_current_temperature": getattr(c, name, None),
+        )
+
+        assert entity.native_value is None
+
 
 class TestKospelMaxPowerLimitSensorNativeValue:
     """Tests for max power limit sensor (kW to W)."""


### PR DESCRIPTION
# Expose room and water temperature sensors (closes #25)

## Summary

Adds Home Assistant **sensor** entities for measured **room** and **DHW water** temperatures so automations and templates can use `sensor.*` state, matching values already shown on the climate and water heater entities.

Completes **Polish** UI strings: new sensor names, the previously untranslated **config flow** and **integration options**, and keeps `pl.json` in key parity with `strings.json`.

## Motivation

[Issue #25](https://github.com/JanKrl/ha-kospel-cmi/issues/25): target and current values on `climate` / `water_heater` are awkward for automations; dedicated measurement sensors follow common HA patterns.

## Changes

### Sensors (`custom_components/kospel/sensor.py`)

- **`room_temperature`** — reads `EkcoM3.room_temperature` (same as climate `current_temperature`).
- **`water_temperature`** — reads `EkcoM3.water_current_temperature` (same as water heater `current_temperature`). Entity id / translation key avoids the word “current”; the library attribute name is unchanged.

Existing setpoint sensors (`room_setpoint`, `supply_setpoint`) are unchanged.

### Strings

- **`custom_components/kospel/strings.json`** — `entity.sensor` entries for `room_temperature` and `water_temperature` (English names).
- **`custom_components/kospel/translations/pl.json`**
  - `entity.sensor`: `room_temperature` → *Temperatura pokoju*, `water_temperature` → *Temperatura wody*.
  - **`config`**: full Polish mirror of `strings.json` (wizard steps, discovery, HTTP step, errors, abort, options / refresh delay) so PL locale no longer falls back to English on setup.

### Tests

- **`tests/test_sensor_entity.py`** — `native_value` coverage for room and water measurement sensors (including missing `water_current_temperature`).

## How to verify

1. Reload the integration or restart Home Assistant.
2. Confirm two new temperature sensors on the device: room and water.
3. With UI language Polish, run through **Add integration** and **Integration options** and confirm Polish strings.

```bash
uv run python -m pytest tests/ -v
```

## Notes

- New `unique_id`s only; no migration.
- Does not duplicate register reads; same coordinator data as existing entities.
