### PR TITLE
Fix wrong target water target temp

### DIFF
--- a/custom_components/kospel/water_heater.py
+++ b/custom_components/kospel/water_heater.py
@@ -107,14 +107,14 @@ class KospelWaterHeaterEntity(
 
     @property
     def target_temperature(self) -> float | None:
-        """Return the target temperature from the active setpoint (mode-dependent)."""
+        """Return the live CWU supply setpoint from the device (register 0b2f).
+
+        Reflects firmware output including daily programs; not derived from
+        static economy/comfort preset registers. ``None`` if the value is
+        unavailable (no substitution).
+        """
         controller = self._get_controller()
-        cwu_mode = controller.cwu_mode
-        if cwu_mode == CwuMode.COMFORT:
-            return controller.cwu_temperature_comfort
-        if cwu_mode == CwuMode.ANTI_FREEZE:
-            return controller.cwu_temperature_economy
-        return controller.cwu_temperature_economy
+        return controller.supply_setpoint
 
     @property
     def current_operation(self) -> str:

--- a/tests/test_water_heater_entity.py
+++ b/tests/test_water_heater_entity.py
@@ -93,50 +93,30 @@ def water_heater_entity(mock_coordinator):
 
 
 class TestWaterHeaterTargetTemperature:
-    """Tests for target_temperature (mode-dependent setpoints)."""
+    """Tests for target_temperature (live supply setpoint only)."""
 
-    def test_target_temperature_returns_economy_setpoint_when_economy_mode(
+    def test_target_temperature_returns_supply_setpoint(
         self, water_heater_entity, mock_coordinator
     ) -> None:
-        """target_temperature returns cwu_temperature_economy when cwu_mode is economy."""
+        """target_temperature returns supply_setpoint regardless of cwu_mode."""
         mock_controller = MagicMock()
-        mock_controller.cwu_mode = CwuMode.ECONOMY
-        mock_controller.cwu_temperature_economy = 40.0
-        mock_controller.cwu_temperature_comfort = 45.0
-        mock_coordinator.data = mock_controller
-
-        assert water_heater_entity.target_temperature == 40.0
-
-    def test_target_temperature_returns_comfort_setpoint_when_comfort_mode(
-        self, water_heater_entity, mock_coordinator
-    ) -> None:
-        """target_temperature returns cwu_temperature_comfort when cwu_mode is comfort."""
-        mock_controller = MagicMock()
-        mock_controller.cwu_mode = CwuMode.COMFORT
-        mock_controller.cwu_temperature_economy = 40.0
-        mock_controller.cwu_temperature_comfort = 45.0
-        mock_coordinator.data = mock_controller
-
-        assert water_heater_entity.target_temperature == 45.0
-
-    def test_target_temperature_returns_economy_setpoint_when_anti_freeze_mode(
-        self, water_heater_entity, mock_coordinator
-    ) -> None:
-        """target_temperature returns cwu_temperature_economy when cwu_mode is anti-freeze."""
-        mock_controller = MagicMock()
+        mock_controller.supply_setpoint = 15.0
         mock_controller.cwu_mode = CwuMode.ANTI_FREEZE
         mock_controller.cwu_temperature_economy = 40.0
+        mock_controller.cwu_temperature_comfort = 45.0
         mock_coordinator.data = mock_controller
 
-        assert water_heater_entity.target_temperature == 40.0
+        assert water_heater_entity.target_temperature == 15.0
 
-    def test_target_temperature_returns_none_when_setpoint_missing(
+    def test_target_temperature_returns_none_when_supply_setpoint_missing(
         self, water_heater_entity, mock_coordinator
     ) -> None:
-        """target_temperature returns None when active setpoint decodes to None."""
+        """target_temperature returns None when supply_setpoint is unavailable."""
         mock_controller = MagicMock()
+        mock_controller.supply_setpoint = None
         mock_controller.cwu_mode = CwuMode.ECONOMY
-        mock_controller.cwu_temperature_economy = None
+        mock_controller.cwu_temperature_economy = 40.0
+        mock_controller.cwu_temperature_comfort = 45.0
         mock_coordinator.data = mock_controller
 
         assert water_heater_entity.target_temperature is None


### PR DESCRIPTION
# Fix wrong DHW target temperature when using daily programs

## Related issue

Fixes [#28 – Wrong water target temperature](https://github.com/JanKrl/ha-kospel-cmi/issues/28).

## Problem

The water heater entity reported `target_temperature` from static CWU preset registers (`cwu_temperature_economy` / `cwu_temperature_comfort`) based on `cwu_mode`. For **anti-freeze** mode the code reused the economy preset, which does not match the temperature chosen by an active **daily program / schedule** (for example program 2 configured for anti-freeze). The device already exposes the live commanded supply setpoint on register `0b2f`, mapped in [kospel-cmi-lib](https://pypi.org/project/kospel-cmi-lib/) as `EkcoM3.supply_setpoint`.

## Solution

- `KospelWaterHeaterEntity.target_temperature` now returns **`controller.supply_setpoint` only** (live supply setpoint, including schedules).
- **No fallback** to economy/comfort presets: if `supply_setpoint` is unavailable (`None`), the target remains `None` instead of substituting a misleading value.
- `current_operation` is unchanged and still reflects `cwu_mode` and water heater enabled state.

## Testing

- Updated unit tests in `tests/test_water_heater_entity.py` for the new contract (supply setpoint present vs missing).
- Full suite: `uv run python -m pytest tests/ -v`.

## Manual follow-up (optional)

On hardware, confirm the HA water heater target matches the heater UI during scheduled slots (especially anti-freeze). If `0b2f` ever tracks the CO circuit instead of DHW in some valve states, a follow-up could gate display logic; not observed in the current integration model.
