### PR TITLE
HVAC Auto / Manual modes and climate preset separation

### DIFF
--- a/custom_components/kospel/climate.py
+++ b/custom_components/kospel/climate.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import TypedDict, Unpack
+from typing import Final, TypedDict, Unpack
 
 from homeassistant.components.climate import (
     ClimateEntity,
@@ -10,6 +10,7 @@ from homeassistant.components.climate import (
     HVACAction,
     HVACMode,
 )
+from homeassistant.components.climate.const import PRESET_NONE
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
@@ -30,6 +31,15 @@ from kospel_cmi.registers.enums import HeaterMode, HeatingStatus
 from kospel_cmi.controller.device import EkcoM3
 
 _LOGGER = logging.getLogger(__name__)
+
+_AUTO_HEATER_MODES: Final[frozenset[HeaterMode]] = frozenset(
+    {
+        HeaterMode.SUMMER,
+        HeaterMode.WINTER,
+        HeaterMode.PARTY,
+        HeaterMode.VACATION,
+    }
+)
 
 
 class _ClimateSetTemperatureKwargs(TypedDict, total=False):
@@ -57,8 +67,14 @@ class KospelClimateEntity(
     _attr_name = None
     _attr_translation_key = "heater"
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
-    _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT]
-    _attr_preset_modes = [mode.value for mode in HeaterMode]
+    _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT, HVACMode.AUTO]
+    _attr_preset_modes = [
+        PRESET_NONE,
+        HeaterMode.WINTER.value,
+        HeaterMode.SUMMER.value,
+        HeaterMode.PARTY.value,
+        HeaterMode.VACATION.value,
+    ]
 
     def __init__(self, coordinator: KospelDataUpdateCoordinator) -> None:
         """Initialize the climate entity."""
@@ -66,8 +82,6 @@ class KospelClimateEntity(
         device_id = get_device_identifier(coordinator.entry)
         self._attr_unique_id = f"{device_id}_climate"
         self._attr_device_info = get_device_info(coordinator.entry)
-
-        self._preset_mode = self._attr_preset_modes[0]
 
     @property
     def _heater_mode(self) -> HeaterMode:
@@ -83,7 +97,12 @@ class KospelClimateEntity(
 
     @property
     def supported_features(self) -> int:
-        """Return supported features; target temperature is shown and sets manual heating when changed."""
+        """Return supported features.
+
+        Target temperature is always advertised so the room setpoint stays visible
+        in every HVAC mode. Changing it still only applies in Heat (manual) mode;
+        see ``async_set_temperature``.
+        """
         return (
             ClimateEntityFeature.PRESET_MODE
             | ClimateEntityFeature.TURN_ON
@@ -93,14 +112,19 @@ class KospelClimateEntity(
 
     @property
     def target_temperature(self) -> float | None:
-        """Return the target temperature (always room_setpoint)."""
+        """Return the target temperature (room setpoint from the controller)."""
         controller: EkcoM3 = self.coordinator.data
         return controller.room_setpoint
 
     @property
     def hvac_mode(self) -> HVACMode:
-        """Current HVAC mode is based on the heater mode (represented in preset)."""
-        return HVACMode.HEAT if self._heater_mode != HeaterMode.OFF else HVACMode.OFF
+        """Map device heater mode to Home Assistant HVAC modes."""
+        mode = self._heater_mode
+        if mode == HeaterMode.OFF:
+            return HVACMode.OFF
+        if mode == HeaterMode.MANUAL:
+            return HVACMode.HEAT
+        return HVACMode.AUTO
 
     @property
     def hvac_action(self) -> HVACAction:
@@ -115,8 +139,13 @@ class KospelClimateEntity(
 
     @property
     def preset_mode(self) -> str | None:
-        """Current preset mode (heater_mode value)."""
-        return self._heater_mode.value
+        """Return the active auto program preset, or ``none`` when not applicable."""
+        mode = self._heater_mode
+        if mode in (HeaterMode.OFF, HeaterMode.MANUAL):
+            return PRESET_NONE
+        if mode in _AUTO_HEATER_MODES:
+            return mode.value
+        return PRESET_NONE
 
     @property
     def available(self) -> bool:
@@ -124,19 +153,37 @@ class KospelClimateEntity(
         return self.coordinator.communication_ok
 
     async def async_turn_on(self) -> None:
-        """Turn heater on (set to HEAT mode)."""
-        await self.async_set_hvac_mode(HVACMode.HEAT)
+        """Turn the heater on using automatic (winter) heating.
+
+        Uses AUTO HVAC mode with the device's default winter program so existing
+        automations that only turn the entity on keep prior seasonal behaviour.
+        """
+        await self.async_set_hvac_mode(HVACMode.AUTO)
 
     async def async_turn_off(self) -> None:
         """Turn heater off."""
         await self.async_set_hvac_mode(HVACMode.OFF)
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
-        """Set new target HVAC mode."""
+        """Set the HVAC mode on the device.
+
+        Args:
+            hvac_mode: Target mode. OFF turns the heater off, HEAT selects manual
+                room control, AUTO selects automatic programs (default winter when
+                only the mode is changed without a preset).
+        """
         _LOGGER.debug("Setting HVAC mode to %s", hvac_mode)
         controller: EkcoM3 = self.coordinator.data
 
-        mode = HeaterMode.OFF if hvac_mode == HVACMode.OFF else HeaterMode.WINTER
+        if hvac_mode == HVACMode.OFF:
+            mode = HeaterMode.OFF
+        elif hvac_mode == HVACMode.HEAT:
+            mode = HeaterMode.MANUAL
+        elif hvac_mode == HVACMode.AUTO:
+            mode = HeaterMode.WINTER
+        else:
+            raise HomeAssistantError(f"Unsupported HVAC mode: {hvac_mode}")
+
         try:
             await controller.set_heater_mode(mode)
         except KospelError as err:
@@ -147,7 +194,17 @@ class KospelClimateEntity(
         await self.coordinator.async_request_refresh()
 
     async def async_set_temperature(self, **kwargs: Unpack[_ClimateSetTemperatureKwargs]) -> None:
-        """Set manual heating target; device switches to MANUAL mode (see EkcoM3.set_manual_heating)."""
+        """Set the manual heating target temperature.
+
+        Raises:
+            HomeAssistantError: If the device is not in manual (heat) mode or the
+                write fails.
+        """
+        if self._heater_mode != HeaterMode.MANUAL:
+            raise HomeAssistantError(
+                "Target temperature can only be set in Heat (manual) mode. "
+                "Switch HVAC mode to Heat first."
+            )
         controller: EkcoM3 = self.coordinator.data
         temperature = kwargs.get("temperature")
         if temperature is not None:
@@ -163,8 +220,21 @@ class KospelClimateEntity(
             await self.coordinator.async_request_refresh()
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
-        """Set new preset mode."""
+        """Set the automatic program (winter, summer, party, vacation).
+
+        Args:
+            preset_mode: Program preset, or ``none`` for a no-op when already idle.
+
+        Raises:
+            HomeAssistantError: If the preset is unknown or the device rejects the change.
+        """
         _LOGGER.debug("Setting preset mode to %s", preset_mode)
+        if preset_mode == PRESET_NONE:
+            return
+
+        if preset_mode not in self._attr_preset_modes:
+            raise HomeAssistantError(f"Unsupported preset mode: {preset_mode}")
+
         controller: EkcoM3 = self.coordinator.data
         try:
             await controller.set_heater_mode(HeaterMode(preset_mode.lower()))

--- a/custom_components/kospel/strings.json
+++ b/custom_components/kospel/strings.json
@@ -152,14 +152,20 @@
       "heater": {
         "name": "Heater",
         "state_attributes": {
-          "preset_mode": {
+          "hvac_mode": {
             "state": {
               "off": "Off",
+              "heat": "Heat",
+              "auto": "Auto"
+            }
+          },
+          "preset_mode": {
+            "state": {
+              "none": "None",
               "summer": "Summer",
               "winter": "Winter",
               "party": "Party",
-              "vacation": "Vacation",
-              "manual": "Manual"
+              "vacation": "Vacation"
             }
           }
         }

--- a/custom_components/kospel/translations/pl.json
+++ b/custom_components/kospel/translations/pl.json
@@ -73,14 +73,20 @@
       "heater": {
         "name": "Grzejnik",
         "state_attributes": {
-          "preset_mode": {
+          "hvac_mode": {
             "state": {
               "off": "Wy\u0142\u0105czony",
+              "heat": "Grzanie",
+              "auto": "Auto"
+            }
+          },
+          "preset_mode": {
+            "state": {
+              "none": "Brak",
               "summer": "Lato",
               "winter": "Zima",
               "party": "Impreza",
-              "vacation": "Wakacje",
-              "manual": "R\u0119czny"
+              "vacation": "Wakacje"
             }
           }
         }

--- a/custom_components/kospel/water_heater.py
+++ b/custom_components/kospel/water_heater.py
@@ -57,8 +57,8 @@ class KospelWaterHeaterEntity(
 
     Read-only for writes: displays current temperature, target temperature, and
     operation mode. Target/operation controls on this entity are intentionally
-    no-ops; DHW/CWU setpoints and modes follow the heater presets and the
-    climate entity, not the water heater card.
+    no-ops; DHW/CWU setpoints and modes follow the device and the climate entity
+    (HVAC / auto programs), not the water heater card.
     """
 
     _attr_has_entity_name = True
@@ -70,7 +70,8 @@ class KospelWaterHeaterEntity(
     _attr_max_temp = 65.0
     # OPERATION_MODE and TARGET_TEMPERATURE are declared so Home Assistant shows
     # current operation and temperatures in the UI. Writes are ignored here by design:
-    # DHW/CWU behaviour is driven by the device and by climate presets (see async_set_*).
+    # DHW/CWU behaviour is driven by the device and by the climate entity (HVAC mode
+    # and auto presets; see climate.async_set_*).
     _attr_supported_features = (
         WaterHeaterEntityFeature.OPERATION_MODE | WaterHeaterEntityFeature.TARGET_TEMPERATURE
     )

--- a/tests/test_climate_entity.py
+++ b/tests/test_climate_entity.py
@@ -1,6 +1,7 @@
-"""Tests for Kospel climate entity (target_temperature, supported_features, async_set_temperature)."""
+"""Tests for Kospel climate entity (HVAC modes, presets, target temperature)."""
 
 import sys
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -25,7 +26,20 @@ sys.modules["homeassistant.components.switch"] = MagicMock()
 sys.modules["homeassistant.components.water_heater"] = MagicMock()
 sys.modules["homeassistant.const"] = MagicMock()
 sys.modules["homeassistant.core"] = MagicMock()
-sys.modules["homeassistant.exceptions"] = MagicMock()
+
+
+class _FakeHomeAssistantError(Exception):
+    """Stand-in for HomeAssistantError in tests."""
+
+
+class _FakeConfigEntryNotReady(_FakeHomeAssistantError):
+    """Stand-in for ConfigEntryNotReady (package __init__ imports it)."""
+
+
+sys.modules["homeassistant.exceptions"] = SimpleNamespace(
+    HomeAssistantError=_FakeHomeAssistantError,
+    ConfigEntryNotReady=_FakeConfigEntryNotReady,
+)
 sys.modules["homeassistant.helpers"] = MagicMock()
 sys.modules["homeassistant.helpers.entity"] = MagicMock()
 sys.modules["homeassistant.helpers.entity_platform"] = MagicMock()
@@ -65,6 +79,9 @@ class _ClimateEntityFeature:
     TURN_OFF = 8
 
 
+climate_const_mock = SimpleNamespace(PRESET_NONE="none")
+sys.modules["homeassistant.components.climate.const"] = climate_const_mock
+
 sys.modules["homeassistant.helpers.update_coordinator"].CoordinatorEntity = (
     _CoordinatorEntityBase
 )
@@ -74,6 +91,7 @@ climate_mock.ClimateEntityFeature = _ClimateEntityFeature
 climate_mock.HVACMode = MagicMock()
 climate_mock.HVACMode.HEAT = "heat"
 climate_mock.HVACMode.OFF = "off"
+climate_mock.HVACMode.AUTO = "auto"
 climate_mock.HVACAction = MagicMock()
 sys.modules["homeassistant.components.climate"] = climate_mock
 
@@ -83,6 +101,8 @@ from custom_components.kospel.climate import KospelClimateEntity
 ClimateEntityFeature = _ClimateEntityFeature
 HVACAction = climate_mock.HVACAction
 HVACMode = climate_mock.HVACMode
+PRESET_NONE = climate_const_mock.PRESET_NONE
+HomeAssistantError = _FakeHomeAssistantError
 
 
 @pytest.fixture
@@ -130,12 +150,12 @@ class TestClimateTargetTemperature:
 
 
 class TestClimateSupportedFeatures:
-    """Tests for supported_features (TARGET_TEMPERATURE always shown for display)."""
+    """Tests for supported_features (TARGET_TEMPERATURE always on for visibility)."""
 
-    def test_supported_features_includes_target_temp_always(
+    def test_supported_features_includes_target_temp_in_manual_and_auto(
         self, climate_entity, mock_coordinator
     ) -> None:
-        """TARGET_TEMPERATURE always included so target is displayed and settable."""
+        """TARGET_TEMPERATURE is always set so the UI can show the room setpoint."""
         for mode in (HeaterMode.WINTER, HeaterMode.MANUAL):
             mock_controller = MagicMock()
             mock_controller.heater_mode = mode
@@ -145,32 +165,77 @@ class TestClimateSupportedFeatures:
             assert (features & ClimateEntityFeature.TARGET_TEMPERATURE) != 0
 
 
+class TestClimateHvacModeAndPreset:
+    """Tests for hvac_mode and preset_mode mapping."""
+
+    def test_hvac_off_preset_none_when_off(
+        self, climate_entity, mock_coordinator
+    ) -> None:
+        """OFF maps to HVAC off and preset none."""
+        mock_controller = MagicMock()
+        mock_controller.heater_mode = HeaterMode.OFF
+        mock_coordinator.data = mock_controller
+
+        assert climate_entity.hvac_mode == HVACMode.OFF
+        assert climate_entity.preset_mode == PRESET_NONE
+
+    def test_hvac_heat_preset_none_when_manual(
+        self, climate_entity, mock_coordinator
+    ) -> None:
+        """MANUAL maps to Heat and preset none."""
+        mock_controller = MagicMock()
+        mock_controller.heater_mode = HeaterMode.MANUAL
+        mock_coordinator.data = mock_controller
+
+        assert climate_entity.hvac_mode == HVACMode.HEAT
+        assert climate_entity.preset_mode == PRESET_NONE
+
+    def test_hvac_auto_preset_winter(
+        self, climate_entity, mock_coordinator
+    ) -> None:
+        """WINTER maps to Auto with winter preset."""
+        mock_controller = MagicMock()
+        mock_controller.heater_mode = HeaterMode.WINTER
+        mock_coordinator.data = mock_controller
+
+        assert climate_entity.hvac_mode == HVACMode.AUTO
+        assert climate_entity.preset_mode == HeaterMode.WINTER.value
+
+    def test_hvac_auto_preset_summer(
+        self, climate_entity, mock_coordinator
+    ) -> None:
+        """SUMMER maps to Auto with summer preset."""
+        mock_controller = MagicMock()
+        mock_controller.heater_mode = HeaterMode.SUMMER
+        mock_coordinator.data = mock_controller
+
+        assert climate_entity.hvac_mode == HVACMode.AUTO
+        assert climate_entity.preset_mode == HeaterMode.SUMMER.value
+
+
 class TestClimateSetTemperature:
     """Tests for async_set_temperature (delegates to set_manual_heating on the device)."""
 
     @pytest.mark.asyncio
-    async def test_set_temperature_calls_set_manual_heating_from_winter_mode(
+    async def test_set_temperature_raises_when_not_manual(
         self, climate_entity, mock_coordinator
     ) -> None:
-        """async_set_temperature calls set_manual_heating even when not already in MANUAL."""
+        """async_set_temperature raises when the device is not in MANUAL."""
         mock_controller = MagicMock()
         mock_controller.heater_mode = HeaterMode.WINTER
         mock_controller.set_manual_heating = AsyncMock(return_value=True)
-        mock_coordinator.async_request_refresh = AsyncMock()
         mock_coordinator.data = mock_controller
-        climate_entity.async_write_ha_state = MagicMock()
 
-        with patch("custom_components.kospel.climate.asyncio.sleep", new_callable=AsyncMock):
+        with pytest.raises(HomeAssistantError, match="Heat \\(manual\\)"):
             await climate_entity.async_set_temperature(temperature=25.0)
 
-        mock_controller.set_manual_heating.assert_called_once_with(25.0)
-        mock_coordinator.async_request_refresh.assert_called_once()
+        mock_controller.set_manual_heating.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_set_temperature_calls_set_manual_heating_when_already_manual(
+    async def test_set_temperature_calls_set_manual_heating_when_manual(
         self, climate_entity, mock_coordinator
     ) -> None:
-        """async_set_temperature still calls set_manual_heating when already in MANUAL."""
+        """async_set_temperature calls set_manual_heating when in MANUAL."""
         mock_controller = MagicMock()
         mock_controller.heater_mode = HeaterMode.MANUAL
         mock_controller.set_manual_heating = AsyncMock(return_value=True)
@@ -183,6 +248,105 @@ class TestClimateSetTemperature:
 
         mock_controller.set_manual_heating.assert_called_once_with(25.0)
         mock_coordinator.async_request_refresh.assert_called_once()
+
+
+class TestClimateSetHvacMode:
+    """Tests for async_set_hvac_mode device mapping."""
+
+    @pytest.mark.asyncio
+    async def test_set_hvac_off_sets_heater_off(
+        self, climate_entity, mock_coordinator
+    ) -> None:
+        """HVAC OFF sets HeaterMode.OFF."""
+        mock_controller = MagicMock()
+        mock_controller.set_heater_mode = AsyncMock()
+        mock_coordinator.async_request_refresh = AsyncMock()
+        mock_coordinator.data = mock_controller
+        climate_entity.async_write_ha_state = MagicMock()
+
+        with patch("custom_components.kospel.climate.asyncio.sleep", new_callable=AsyncMock):
+            await climate_entity.async_set_hvac_mode(HVACMode.OFF)
+
+        mock_controller.set_heater_mode.assert_called_once_with(HeaterMode.OFF)
+
+    @pytest.mark.asyncio
+    async def test_set_hvac_heat_sets_manual(
+        self, climate_entity, mock_coordinator
+    ) -> None:
+        """HVAC HEAT sets HeaterMode.MANUAL."""
+        mock_controller = MagicMock()
+        mock_controller.set_heater_mode = AsyncMock()
+        mock_coordinator.async_request_refresh = AsyncMock()
+        mock_coordinator.data = mock_controller
+        climate_entity.async_write_ha_state = MagicMock()
+
+        with patch("custom_components.kospel.climate.asyncio.sleep", new_callable=AsyncMock):
+            await climate_entity.async_set_hvac_mode(HVACMode.HEAT)
+
+        mock_controller.set_heater_mode.assert_called_once_with(HeaterMode.MANUAL)
+
+    @pytest.mark.asyncio
+    async def test_set_hvac_auto_sets_winter_default(
+        self, climate_entity, mock_coordinator
+    ) -> None:
+        """HVAC AUTO defaults to HeaterMode.WINTER."""
+        mock_controller = MagicMock()
+        mock_controller.set_heater_mode = AsyncMock()
+        mock_coordinator.async_request_refresh = AsyncMock()
+        mock_coordinator.data = mock_controller
+        climate_entity.async_write_ha_state = MagicMock()
+
+        with patch("custom_components.kospel.climate.asyncio.sleep", new_callable=AsyncMock):
+            await climate_entity.async_set_hvac_mode(HVACMode.AUTO)
+
+        mock_controller.set_heater_mode.assert_called_once_with(HeaterMode.WINTER)
+
+
+class TestClimateSetPresetMode:
+    """Tests for async_set_preset_mode."""
+
+    @pytest.mark.asyncio
+    async def test_set_preset_none_is_noop(
+        self, climate_entity, mock_coordinator
+    ) -> None:
+        """Preset 'none' does not call the controller."""
+        mock_controller = MagicMock()
+        mock_controller.set_heater_mode = AsyncMock()
+        mock_coordinator.data = mock_controller
+
+        await climate_entity.async_set_preset_mode(PRESET_NONE)
+
+        mock_controller.set_heater_mode.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_set_preset_summer_calls_controller(
+        self, climate_entity, mock_coordinator
+    ) -> None:
+        """Setting summer preset writes HeaterMode.SUMMER."""
+        mock_controller = MagicMock()
+        mock_controller.set_heater_mode = AsyncMock()
+        mock_coordinator.async_request_refresh = AsyncMock()
+        mock_coordinator.data = mock_controller
+        climate_entity.async_write_ha_state = MagicMock()
+
+        with patch("custom_components.kospel.climate.asyncio.sleep", new_callable=AsyncMock):
+            await climate_entity.async_set_preset_mode(HeaterMode.SUMMER.value)
+
+        mock_controller.set_heater_mode.assert_called_once_with(HeaterMode.SUMMER)
+
+    @pytest.mark.asyncio
+    async def test_set_preset_invalid_raises(
+        self, climate_entity, mock_coordinator
+    ) -> None:
+        """Unknown preset raises HomeAssistantError."""
+        mock_controller = MagicMock()
+        mock_controller.set_heater_mode = AsyncMock()
+        mock_coordinator.data = mock_controller
+
+        with pytest.raises(HomeAssistantError, match="Unsupported preset"):
+            await climate_entity.async_set_preset_mode("not_a_mode")
+
+        mock_controller.set_heater_mode.assert_not_called()
 
 
 class TestClimateHvacAction:
@@ -223,13 +387,13 @@ class TestClimateTurnOnOff:
     """Tests for async_turn_on and async_turn_off (delegate to async_set_hvac_mode)."""
 
     @pytest.mark.asyncio
-    async def test_turn_on_calls_set_hvac_mode_heat(
+    async def test_turn_on_calls_set_hvac_mode_auto(
         self, climate_entity, mock_coordinator
     ) -> None:
-        """async_turn_on delegates to async_set_hvac_mode(HVACMode.HEAT)."""
+        """async_turn_on delegates to async_set_hvac_mode(AUTO) for seasonal default."""
         climate_entity.async_set_hvac_mode = AsyncMock()
         await climate_entity.async_turn_on()
-        climate_entity.async_set_hvac_mode.assert_called_once_with(HVACMode.HEAT)
+        climate_entity.async_set_hvac_mode.assert_called_once_with(HVACMode.AUTO)
 
     @pytest.mark.asyncio
     async def test_turn_off_calls_set_hvac_mode_off(


### PR DESCRIPTION
# HVAC Auto / Manual modes and climate preset separation

Related: #30

## Summary

This branch refines how the **climate** entity maps Kospel heater modes to Home Assistant **HVAC modes** and **presets**. Automatic programs (winter, summer, party, vacation) are exposed under **Auto** with **preset** selection; **manual** room control is **Heat**. Target temperature stays visible in the UI for all modes, but changing it is only allowed in **Heat (manual)**.

## Motivation

- Distinguish **automatic** heating programs from **manual** room setpoint control using HA’s familiar **Off / Heat / Auto** model.
- Avoid treating “manual” as a preset alongside seasonal programs; presets now represent auto programs only, with `none` when off or in manual.
- **`async_turn_on`** continues to “turn heating on” in a sensible default way by selecting **Auto** with winter (previous behavior effectively aligned with automatic winter, not raw manual).

## User-visible behavior

| Device `HeaterMode` | HA `hvac_mode` | `preset_mode` |
|---------------------|----------------|---------------|
| `OFF` | `off` | `none` |
| `MANUAL` | `heat` | `none` |
| `WINTER`, `SUMMER`, `PARTY`, `VACATION` | `auto` | matching program value |

- **Target temperature**: Still reported from the controller in every mode so the room setpoint remains visible. **`async_set_temperature`** raises `HomeAssistantError` unless the device is already in **MANUAL**; users must switch to **Heat** first.
- **`async_set_hvac_mode`**: Maps `OFF` → off, `HEAT` → `HeaterMode.MANUAL`, `AUTO` → `HeaterMode.WINTER` (default program when only mode is changed). Unsupported modes raise `HomeAssistantError`.
- **`async_set_preset_mode`**: `none` is a no-op. Other values must be a supported auto preset; invalid values raise `HomeAssistantError`.
- **`async_turn_on`**: Calls **`async_set_hvac_mode(AUTO)`** (winter default via mapping above).

## Strings / translations

- **English** (`strings.json`) and **Polish** (`translations/pl.json`): Added `hvac_mode` state strings (`off`, `heat`, `auto`). Preset strings now include `none` and drop `manual` from preset labels (manual is represented by HVAC **Heat**).

## Documentation

- **`water_heater.py`**: Docstrings updated to clarify that DHW behavior follows the device and the **climate** entity (HVAC mode and auto presets), not the water heater card.
- **Brand assets** (`custom_components/kospel/brand/*.png`): Updated logo/icon variants to improve UI presentation with transparent background trimming and refined ring boundary.

## Tests

- **`tests/test_climate_entity.py`**: Expanded coverage for `hvac_mode` / `preset_mode` mapping, `async_set_hvac_mode`, `async_set_preset_mode`, stricter `async_set_temperature` behavior, and `async_turn_on` → **AUTO**.

## How to verify

```bash
uv sync --all-groups
uv run python -m pytest tests/test_climate_entity.py -v
```

## Checklist

- [x] Climate mapping matches HA semantics (Off / Heat / Auto + presets for auto programs).
- [x] Translations updated for new attributes.
- [x] Unit tests updated and aligned with new rules.
