### PR TITLE
Unify naming

### DIFF
--- a/custom_components/kospel/climate.py
+++ b/custom_components/kospel/climate.py
@@ -128,12 +128,12 @@ class KospelClimateEntity(
 
     @property
     def hvac_action(self) -> HVACAction:
-        """HVAC action is based on whether CO heating circuit is active."""
+        """HVAC action is based on whether CH heating circuit is active."""
         controller: EkcoM3 = self.coordinator.data
-        co_status = controller.co_heating_status
+        ch_status = controller.co_heating_status
         return (
             HVACAction.HEATING
-            if co_status == HeatingStatus.RUNNING
+            if ch_status == HeatingStatus.RUNNING
             else HVACAction.OFF
         )
 

--- a/custom_components/kospel/sensor.py
+++ b/custom_components/kospel/sensor.py
@@ -58,11 +58,11 @@ async def async_setup_entry(
 
     # Heating status sensors: (unique_id_suffix, setting_name)
     entities.append(
-        KospelHeatingStatusSensor(coordinator, entry, "co_heating", "co_heating_status")
+        KospelHeatingStatusSensor(coordinator, entry, "ch_heating", "co_heating_status")
     )
     entities.append(
         KospelHeatingStatusSensor(
-            coordinator, entry, "cwu_heating", "cwu_heating_status"
+            coordinator, entry, "dhw_heating", "cwu_heating_status"
         )
     )
     entities.append(KospelValvePositionSensor(coordinator, entry))
@@ -219,7 +219,7 @@ class KospelMaxPowerLimitSensor(KospelSensorEntity):
 
 
 class KospelHeatingStatusSensor(KospelSensorEntity):
-    """Representation of a Kospel heating status sensor (CO or CWU circuit)."""
+    """Representation of a Kospel heating status sensor (CH or CWU circuit)."""
 
     def __init__(
         self,

--- a/custom_components/kospel/strings.json
+++ b/custom_components/kospel/strings.json
@@ -91,33 +91,33 @@
     },
     "sensor": {
       "room_setpoint": {
-        "name": "Room Setpoint"
+        "name": "CH target temperature"
       },
       "supply_setpoint": {
-        "name": "DHW Setpoint"
+        "name": "DHW target temperature"
       },
       "room_temperature": {
-        "name": "Room temperature"
+        "name": "CH temperature"
       },
       "water_temperature": {
-        "name": "Water temperature"
+        "name": "DHW temperature"
       },
       "pressure": {
         "name": "Pressure"
       },
       "power": {
-        "name": "Power"
+        "name": "Instant power"
       },
-      "co_heating": {
-        "name": "CO Heating",
+      "ch_heating": {
+        "name": "CH heating status",
         "state": {
           "running": "Running",
           "idle": "Idle",
           "disabled": "Disabled"
         }
       },
-      "cwu_heating": {
-        "name": "CWU Heating",
+      "dhw_heating": {
+        "name": "DHW heating status",
         "state": {
           "running": "Running",
           "idle": "Idle",
@@ -128,11 +128,11 @@
         "name": "Valve Position",
         "state": {
           "DHW": "DHW",
-          "CO": "CO"
+          "CO": "CH"
         }
       },
       "max_power_limit": {
-        "name": "Max power limit"
+        "name": "Boiler max power limit"
       }
     },
     "number": {

--- a/custom_components/kospel/translations/pl.json
+++ b/custom_components/kospel/translations/pl.json
@@ -91,33 +91,33 @@
     },
     "sensor": {
       "room_setpoint": {
-        "name": "Nastawa pokojowa"
+        "name": "Temperatura zadana CO"
       },
       "supply_setpoint": {
-        "name": "Nastawa CWU"
+        "name": "Temperatura zadana CWU"
       },
       "room_temperature": {
-        "name": "Temperatura pokoju"
+        "name": "Temperatura CO"
       },
       "water_temperature": {
-        "name": "Temperatura wody"
+        "name": "Temperatura CWU"
       },
       "pressure": {
         "name": "Ci\u015bnienie"
       },
       "power": {
-        "name": "Moc"
+        "name": "Moc chwilowa"
       },
-      "co_heating": {
-        "name": "Ogrzewanie CO",
+      "ch_heating": {
+        "name": "Status ogrzewania CO",
         "state": {
           "running": "Praca",
           "idle": "Bezczynno\u015b\u0107",
           "disabled": "Wy\u0142\u0105czone"
         }
       },
-      "cwu_heating": {
-        "name": "Ogrzewanie CWU",
+      "dhw_heating": {
+        "name": "Status ogrzewania CWU",
         "state": {
           "running": "Praca",
           "idle": "Bezczynno\u015b\u0107",
@@ -125,14 +125,14 @@
         }
       },
       "valve_position": {
-        "name": "Pozycja zaworu",
+        "name": "Położenie zaworu",
         "state": {
           "DHW": "CWU",
           "CO": "CO"
         }
       },
       "max_power_limit": {
-        "name": "Limit mocy"
+        "name": "Limit mocy kotła"
       }
     },
     "number": {

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -14,6 +14,14 @@ This project provides a Home Assistant integration for Kospel electric heaters. 
 
 ## Home Assistant Integration
 
+### Naming Convention
+
+- Internal code identifiers (entity translation keys, variable names, comments, tests) use English terminology.
+- Device-library compatibility fields keep library naming where required (for example `co_heating_status`, `cwu_heating_status`) and are mapped to English integration keys.
+- User-facing labels are localized in translation files:
+  - `strings.json`: English labels (`CH`, `DHW`)
+  - `translations/pl.json`: Polish labels (`CO`, `CWU`)
+
 ### Import Rules
 
 The integration uses **kospel-cmi-lib** for heater communication. Imports use absolute paths to the installed package:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ def sample_registers() -> Dict[str, str]:
         # Value: 0x0208 = 0b0000001000001000 (bits 3 and 9 set)
         "0b55": "0802",
         # Register 0b51 - Status register (pumps and valve)
-        # Bit 0=1 (pump CO running), Bit 1=0, Bit 2=1 (valve CO position)
+        # Bit 0=1 (pump CH running), Bit 1=0, Bit 2=1 (valve CH position)
         # Value: 0x0005 = 0b0000000000000101 (bits 0 and 2 set)
         "0b51": "0500",
         # Register 0b8d - Manual temperature (215 = 21.5°C)
@@ -73,7 +73,7 @@ def sample_registers() -> Dict[str, str]:
         "0b62": "0000",
         # Register 0b2f - Supply setpoint CWU (450 = 45.0°C)
         "0b2f": "c201",
-        # Register 0b31 - Room setpoint CO (220 = 22.0°C)
+        # Register 0b31 - Room setpoint CH (220 = 22.0°C)
         "0b31": "dc00",
         # Register 0b30 - CWU mode (0=economy, 1=anti-freeze, 2=comfort)
         "0b30": "0000",

--- a/tests/integration/test_water_heater_registers.py
+++ b/tests/integration/test_water_heater_registers.py
@@ -49,6 +49,6 @@ class TestWaterHeaterRegisters:
     async def test_room_setpoint_decoded(
         self, heater_controller_with_registers: EkcoM3
     ) -> None:
-        """room_setpoint (CO) is decoded from register 0b31."""
+        """room_setpoint (CH) is decoded from register 0b31."""
         controller = heater_controller_with_registers
         assert controller.room_setpoint == 22.0

--- a/tests/test_climate_entity.py
+++ b/tests/test_climate_entity.py
@@ -350,32 +350,32 @@ class TestClimateSetPresetMode:
 
 
 class TestClimateHvacAction:
-    """Tests for hvac_action (heating indicator based on co_heating_status)."""
+    """Tests for hvac_action (heating indicator based on CH status)."""
 
-    def test_hvac_action_heating_when_co_heating_status_running(
+    def test_hvac_action_heating_when_ch_status_running(
         self, climate_entity, mock_coordinator
     ) -> None:
-        """hvac_action returns HEATING when co_heating_status is RUNNING."""
+        """hvac_action returns HEATING when CH status is RUNNING."""
         mock_controller = MagicMock()
         mock_controller.co_heating_status = HeatingStatus.RUNNING
         mock_coordinator.data = mock_controller
 
         assert climate_entity.hvac_action == HVACAction.HEATING
 
-    def test_hvac_action_off_when_co_heating_status_idle(
+    def test_hvac_action_off_when_ch_status_idle(
         self, climate_entity, mock_coordinator
     ) -> None:
-        """hvac_action returns OFF when co_heating_status is IDLE."""
+        """hvac_action returns OFF when CH status is IDLE."""
         mock_controller = MagicMock()
         mock_controller.co_heating_status = HeatingStatus.IDLE
         mock_coordinator.data = mock_controller
 
         assert climate_entity.hvac_action == HVACAction.OFF
 
-    def test_hvac_action_off_when_co_heating_status_disabled(
+    def test_hvac_action_off_when_ch_status_disabled(
         self, climate_entity, mock_coordinator
     ) -> None:
-        """hvac_action returns OFF when co_heating_status is DISABLED."""
+        """hvac_action returns OFF when CH status is DISABLED."""
         mock_controller = MagicMock()
         mock_controller.co_heating_status = HeatingStatus.DISABLED
         mock_coordinator.data = mock_controller


### PR DESCRIPTION
## Summary

- Unify internal naming from `CO/CWU` to `CH/DHW` for better consistency in code and entity labels.
- Update climate/sensor naming comments and test wording to match the CH/DHW terminology.
- Refresh user-facing English and Polish translations for clearer sensor names.
- Document naming convention rules in `docs/technical.md`.

## Breaking change

- This PR intentionally changes sensor translation keys and unique-id suffixes for heating status sensors:
  - `co_heating` -> `ch_heating`
  - `cwu_heating` -> `dhw_heating`
- As a result, existing Home Assistant entities for those two sensors will be recreated under new IDs, and automations/dashboards using old entity IDs must be updated manually.

## Why

- Existing naming mixed Polish/library terminology (`CO`, `CWU`) with English integration terminology.
- The new convention keeps low-level library compatibility fields as-is (`co_heating_status`, `cwu_heating_status`) while exposing consistent English identifiers and labels at integration level.

## Scope of changes

- `custom_components/kospel/sensor.py`
  - Rename heating status sensor keys to `ch_heating` and `dhw_heating`.
- `custom_components/kospel/strings.json`
  - Update English labels for temperature, power, heating status, valve position state label, and max power limit naming.
- `custom_components/kospel/translations/pl.json`
  - Update Polish labels to align with the new naming and improve clarity.
- `custom_components/kospel/climate.py`
  - Update CH wording in HVAC action naming/comments (no behavior change).
- `tests/*`
  - Update test names/comments to match CH terminology.
- `docs/technical.md`
  - Add explicit naming convention section.

## Test plan

- [x] Run targeted tests related to touched areas:
  - `uv run python -m pytest tests/test_climate_entity.py tests/integration/test_water_heater_registers.py -q`
- [x] Result: `25 passed`
- [ ] Manual QA in Home Assistant:
  - Confirm new entities appear with expected labels.
  - Rebind automations/dashboards from old `co_heating`/`cwu_heating` entity IDs to new `ch_heating`/`dhw_heating`.

## Notes for reviewers

- This is an intentional breaking change for entity identity.
- Backward compatibility is not preserved in this PR by design.
