### PR TITLE
Feature/autodiscovery flow

### DIFF
--- a/custom_components/kospel/config_flow.py
+++ b/custom_components/kospel/config_flow.py
@@ -43,6 +43,11 @@ class CannotConnect(Exception):
 
 
 _DHCP_CANDIDATE_HOSTS: set[str] = set()
+# NOTE:
+# Auto-discovery via DHCP/OUI is intentionally kept in code but hidden from
+# the user-facing flow. During field testing we observed MAC-prefix mismatch
+# on a real device, so the manifest DHCP matcher is disabled for now.
+# Keep this logic for future re-enable once OUI matching is verified.
 
 
 def _normalize_mac(mac: str | None) -> str | None:
@@ -64,7 +69,11 @@ def _is_kospel_mac(mac: str | None) -> bool:
 async def _discover_by_kospel_mac(
     session: aiohttp.ClientSession,
 ) -> list[tuple[Any, int]]:
-    """Discover devices from DHCP auto-discovered Kospel candidates."""
+    """Discover devices from DHCP auto-discovered Kospel candidates.
+
+    This path is currently dormant in normal UX because we hide auto-discovery
+    until MAC-prefix matching for real devices is validated.
+    """
     if not _DHCP_CANDIDATE_HOSTS:
         LOGGER.debug("Auto discovery has no DHCP candidate hosts")
         return []
@@ -188,7 +197,6 @@ class KospelConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         """Initialize config flow."""
-        self._backend_type: str | None = None
         self._discovered_devices: list[
             tuple[Any, int]
         ] = []  # (KospelDeviceInfo, device_id)
@@ -196,7 +204,10 @@ class KospelConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self._discover_task: asyncio.Task[None] | None = None
 
     async def async_step_dhcp(self, discovery_info: dict[str, Any]) -> FlowResult:
-        """Handle discovery from Home Assistant DHCP integration."""
+        """Handle discovery from Home Assistant DHCP integration.
+
+        Kept for future re-enable when DHCP matcher is restored in manifest.
+        """
         mac_address = discovery_info.get("macaddress")
         if not _is_kospel_mac(mac_address):
             LOGGER.debug(
@@ -255,31 +266,25 @@ class KospelConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Handle the initial step: choose backend type (HTTP or YAML)."""
+        """Handle initial step with connection mode choices."""
         if user_input is None:
             return self.async_show_form(
                 step_id="user",
                 data_schema=vol.Schema(
                     {
-                        vol.Required(
-                            CONF_BACKEND_TYPE,
-                            default=BACKEND_TYPE_HTTP,
-                        ): vol.In(
+                        vol.Required("connection_mode", default="network_scan"): vol.In(
                             {
-                                BACKEND_TYPE_HTTP: "option_http",
-                                BACKEND_TYPE_YAML: "option_yaml",
+                                "network_scan": "Network scan",
+                                "manual": "Manual entry",
+                                "yaml": "YAML (for development only)",
                             }
-                        ),
+                        )
                     }
                 ),
-                description_placeholders={
-                    "yaml_path": "custom_components/kospel/data/state.yaml",
-                },
             )
 
-        self._backend_type = user_input[CONF_BACKEND_TYPE]
-
-        if self._backend_type == BACKEND_TYPE_YAML:
+        mode = user_input["connection_mode"]
+        if mode == "yaml":
             return self.async_create_entry(
                 title="Kospel Heater (YAML / development)",
                 data={
@@ -287,43 +292,13 @@ class KospelConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 },
             )
 
-        # HTTP: show connection method choice.
-        return self.async_show_form(
-            step_id="http_method",
-            data_schema=vol.Schema(
-                {
-                    vol.Required("http_method", default="auto_discovery"): vol.In(
-                        {
-                            "auto_discovery": "option_auto_discovery",
-                            "network_scan": "option_network_scan",
-                            "manual": "option_manual",
-                        }
-                    ),
-                }
-            ),
-        )
+        return await self._async_continue_http_method(mode)
 
-    async def async_step_http_method(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Handle HTTP connection method selection."""
-        if user_input is None:
-            return self.async_show_form(
-                step_id="http_method",
-                data_schema=vol.Schema(
-                    {
-                        vol.Required("http_method", default="auto_discovery"): vol.In(
-                            {
-                                "auto_discovery": "option_auto_discovery",
-                                "network_scan": "option_network_scan",
-                                "manual": "option_manual",
-                            }
-                        ),
-                    }
-                ),
-            )
-
-        method = user_input["http_method"]
+    async def _async_continue_http_method(self, method: str) -> FlowResult:
+        """Continue flow for selected HTTP method."""
+        # Keep auto_discovery implementation for future use, but hide it from UI
+        # because current MAC prefix assumptions do not match at least one
+        # production device and need investigation before re-enabling.
         if method in {"auto_discovery", "network_scan"}:
             self._discover_task = None
             self._discovery_method = method
@@ -338,6 +313,28 @@ class KospelConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 }
             ),
         )
+
+    async def async_step_http_method(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle HTTP connection method selection (legacy step)."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="http_method",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required("http_method", default="auto_discovery"): vol.In(
+                            {
+                                "auto_discovery": "Auto discovery",
+                                "network_scan": "Network scan",
+                                "manual": "Manual entry",
+                            }
+                        ),
+                    }
+                ),
+            )
+
+        return await self._async_continue_http_method(user_input["http_method"])
 
     async def _async_run_discovery(self) -> None:
         """Run discovery task and store results for discover_result step."""
@@ -378,7 +375,7 @@ class KospelConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Scan network for Kospel devices."""
-        LOGGER.warning(
+        LOGGER.info(
             "Discovery UI step entered (method=%s)",
             self._discovery_method,
         )
@@ -407,7 +404,9 @@ class KospelConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         if self._discover_task is None:
             LOGGER.debug("Creating new discovery progress task")
-            self._discover_task = self.hass.async_create_task(self._async_run_discovery())
+            self._discover_task = self.hass.async_create_task(
+                self._async_run_discovery()
+            )
         elif not self._discover_task.done():
             LOGGER.debug("Reusing running discovery progress task")
         else:
@@ -437,8 +436,8 @@ class KospelConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     {
                         vol.Required("action", default="manual"): vol.In(
                             {
-                                "retry": "option_retry",
-                                "manual": "option_manual",
+                                "retry": "Retry scan",
+                                "manual": "Manual entry",
                             }
                         ),
                     }

--- a/custom_components/kospel/config_flow.py
+++ b/custom_components/kospel/config_flow.py
@@ -1,6 +1,9 @@
 """Config flow for Kospel integration."""
 
+import asyncio
+import logging
 from ipaddress import ip_interface
+from ipaddress import ip_network
 from typing import Any
 
 import aiohttp
@@ -22,7 +25,7 @@ from .const import (
     CONF_SERIAL_NUMBER,
     CONF_SIMULATION_MODE,
     DEFAULT_REFRESH_DELAY_AFTER_SET,
-    DEFAULT_SUBNETS,
+    KOSPEL_MAC_PREFIXES,
     BACKEND_TYPE_HTTP,
     BACKEND_TYPE_YAML,
     REFRESH_DELAY_MAX,
@@ -30,9 +33,59 @@ from .const import (
     make_unique_id,
 )
 
+LOGGER = logging.getLogger(__name__)
+DISCOVERY_TIMEOUT_SECONDS = 90.0
+MAX_NETWORK_SCAN_HOSTS = 1024
+
 
 class CannotConnect(Exception):
     """Raised when connection to heater fails."""
+
+
+_DHCP_CANDIDATE_HOSTS: set[str] = set()
+
+
+def _normalize_mac(mac: str | None) -> str | None:
+    """Return lowercase hex-only MAC string or None for invalid values."""
+    if not mac:
+        return None
+    normalized = "".join(char for char in mac.lower() if char in "0123456789abcdef")
+    return normalized if len(normalized) >= 9 else None
+
+
+def _is_kospel_mac(mac: str | None) -> bool:
+    """Return True when MAC belongs to known Kospel vendor prefixes."""
+    normalized = _normalize_mac(mac)
+    if normalized is None:
+        return False
+    return any(normalized.startswith(prefix) for prefix in KOSPEL_MAC_PREFIXES)
+
+
+async def _discover_by_kospel_mac(
+    session: aiohttp.ClientSession,
+) -> list[tuple[Any, int]]:
+    """Discover devices from DHCP auto-discovered Kospel candidates."""
+    if not _DHCP_CANDIDATE_HOSTS:
+        LOGGER.debug("Auto discovery has no DHCP candidate hosts")
+        return []
+
+    LOGGER.debug(
+        "Auto discovery probing DHCP candidates: %s",
+        sorted(_DHCP_CANDIDATE_HOSTS),
+    )
+    probe_results = await asyncio.gather(
+        *[probe_device(session, host) for host in sorted(_DHCP_CANDIDATE_HOSTS)],
+        return_exceptions=True,
+    )
+
+    discovered: list[tuple[Any, int]] = []
+    for result in probe_results:
+        if isinstance(result, Exception) or result is None:
+            continue
+        for device_id in result.device_ids:
+            discovered.append((result, device_id))
+    LOGGER.debug("Auto discovery found %s device candidates", len(discovered))
+    return discovered
 
 
 async def validate_http_input(
@@ -67,11 +120,12 @@ async def validate_http_input(
 
 
 async def _get_subnets_to_scan(hass: HomeAssistant) -> list[str]:
-    """Get subnets to scan from Network integration or fallback to defaults."""
+    """Get subnets to scan from enabled IPv4 adapters."""
     try:
         adapters = await network.async_get_adapters(hass)
     except Exception:
-        return DEFAULT_SUBNETS
+        LOGGER.exception("Could not read network adapters for subnet scan")
+        return []
 
     subnets: set[str] = set()
     for adapter in adapters:
@@ -79,14 +133,52 @@ async def _get_subnets_to_scan(hass: HomeAssistant) -> list[str]:
             continue
         for ipv4 in adapter.get("ipv4", []):
             try:
-                iface = ip_interface(
-                    f"{ipv4['address']}/{ipv4['network_prefix']}"
-                )
+                iface = ip_interface(f"{ipv4['address']}/{ipv4['network_prefix']}")
                 subnets.add(str(iface.network))
             except (ValueError, KeyError):
                 continue
 
-    return list(subnets) if subnets else DEFAULT_SUBNETS
+    result = sorted(subnets)
+    LOGGER.debug("Network scan subnets resolved: %s", result)
+    return result
+
+
+async def _discover_by_network_scan(
+    hass: HomeAssistant, session: aiohttp.ClientSession
+) -> list[tuple[Any, int]]:
+    """Discover devices by scanning all IPv4 subnets from network adapters."""
+    subnets = await _get_subnets_to_scan(hass)
+    if not subnets:
+        LOGGER.warning("Network scan has no enabled IPv4 subnets to scan")
+        return []
+
+    discovered: list[tuple[Any, int]] = []
+    for subnet in subnets:
+        try:
+            network_obj = ip_network(subnet, strict=False)
+            host_count = max(0, int(network_obj.num_addresses) - 2)
+        except ValueError:
+            LOGGER.warning("Skipping invalid subnet from adapter list: %s", subnet)
+            continue
+
+        if host_count > MAX_NETWORK_SCAN_HOSTS:
+            LOGGER.warning(
+                "Skipping large subnet %s (%s hosts > limit %s)",
+                subnet,
+                host_count,
+                MAX_NETWORK_SCAN_HOSTS,
+            )
+            continue
+
+        LOGGER.info("Network scan probing subnet=%s", subnet)
+        devices = await discover_devices(
+            session, subnet, timeout=3.0, concurrency_limit=20
+        )
+        for info in devices:
+            for device_id in info.device_ids:
+                discovered.append((info, device_id))
+    LOGGER.debug("Network scan found %s device candidates", len(discovered))
+    return discovered
 
 
 class KospelConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -97,7 +189,68 @@ class KospelConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         """Initialize config flow."""
         self._backend_type: str | None = None
-        self._discovered_devices: list[tuple[Any, int]] = []  # (KospelDeviceInfo, device_id)
+        self._discovered_devices: list[
+            tuple[Any, int]
+        ] = []  # (KospelDeviceInfo, device_id)
+        self._discovery_method: str = "auto_discovery"
+        self._discover_task: asyncio.Task[None] | None = None
+
+    async def async_step_dhcp(self, discovery_info: dict[str, Any]) -> FlowResult:
+        """Handle discovery from Home Assistant DHCP integration."""
+        mac_address = discovery_info.get("macaddress")
+        if not _is_kospel_mac(mac_address):
+            LOGGER.debug(
+                "Ignoring DHCP discovery with non-Kospel MAC: %s",
+                mac_address,
+            )
+            return self.async_abort(reason="not_kospel_device")
+
+        host = discovery_info.get("ip")
+        if not isinstance(host, str):
+            LOGGER.warning("DHCP discovery missing IP field: %s", discovery_info)
+            return self.async_abort(reason="unknown")
+
+        _DHCP_CANDIDATE_HOSTS.add(host)
+        LOGGER.info(
+            "Stored DHCP discovery candidate host=%s (total_candidates=%s)",
+            host,
+            len(_DHCP_CANDIDATE_HOSTS),
+        )
+
+        async with aiohttp.ClientSession() as session:
+            info = await probe_device(session, host)
+        if info is None or not info.device_ids:
+            LOGGER.warning("DHCP candidate probe failed for host=%s", host)
+            return self.async_abort(reason="cannot_connect")
+
+        if len(info.device_ids) == 1:
+            device_id = info.device_ids[0]
+            unique_id = make_unique_id(info.serial_number, device_id)
+            await self.async_set_unique_id(unique_id)
+            self._abort_if_unique_id_configured()
+            heater_ip = info.host.split(":")[0] if ":" in info.host else info.host
+            LOGGER.info(
+                "DHCP discovery created entry host=%s device_id=%s",
+                heater_ip,
+                device_id,
+            )
+            return self.async_create_entry(
+                title=f"Kospel Heater {heater_ip} (device {device_id})",
+                data={
+                    CONF_BACKEND_TYPE: BACKEND_TYPE_HTTP,
+                    CONF_HEATER_IP: heater_ip,
+                    CONF_DEVICE_ID: device_id,
+                    CONF_SERIAL_NUMBER: info.serial_number,
+                },
+            )
+
+        self._discovered_devices = [(info, device_id) for device_id in info.device_ids]
+        LOGGER.info(
+            "DHCP discovery found multiple device IDs at host=%s: %s",
+            host,
+            info.device_ids,
+        )
+        return await self.async_step_discover_result()
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -134,14 +287,15 @@ class KospelConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 },
             )
 
-        # HTTP: show connection method choice (Discover vs Manual)
+        # HTTP: show connection method choice.
         return self.async_show_form(
             step_id="http_method",
             data_schema=vol.Schema(
                 {
-                    vol.Required("http_method", default="discover"): vol.In(
+                    vol.Required("http_method", default="auto_discovery"): vol.In(
                         {
-                            "discover": "option_discover",
+                            "auto_discovery": "option_auto_discovery",
+                            "network_scan": "option_network_scan",
                             "manual": "option_manual",
                         }
                     ),
@@ -152,15 +306,16 @@ class KospelConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_http_method(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Handle HTTP connection method: Discover or Manual."""
+        """Handle HTTP connection method selection."""
         if user_input is None:
             return self.async_show_form(
                 step_id="http_method",
                 data_schema=vol.Schema(
                     {
-                        vol.Required("http_method", default="discover"): vol.In(
+                        vol.Required("http_method", default="auto_discovery"): vol.In(
                             {
-                                "discover": "option_discover",
+                                "auto_discovery": "option_auto_discovery",
+                                "network_scan": "option_network_scan",
                                 "manual": "option_manual",
                             }
                         ),
@@ -168,7 +323,11 @@ class KospelConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 ),
             )
 
-        if user_input["http_method"] == "discover":
+        method = user_input["http_method"]
+        if method in {"auto_discovery", "network_scan"}:
+            self._discover_task = None
+            self._discovery_method = method
+            LOGGER.info("HTTP discovery method selected: %s", method)
             return await self.async_step_discover()
         return self.async_show_form(
             step_id="http",
@@ -180,31 +339,49 @@ class KospelConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             ),
         )
 
-    async def _async_run_discovery(self) -> FlowResult:
-        """Run network discovery and return progress_done to transition to result step."""
+    async def _async_run_discovery(self) -> None:
+        """Run discovery task and store results for discover_result step."""
         try:
-            subnets = await _get_subnets_to_scan(self.hass)
+            LOGGER.info("Starting discovery run via method=%s", self._discovery_method)
             all_devices: list[tuple[Any, int]] = []
 
             async with aiohttp.ClientSession() as session:
-                for subnet in subnets:
-                    devices = await discover_devices(
-                        session, subnet, timeout=3.0, concurrency_limit=20
+                if self._discovery_method == "network_scan":
+                    all_devices = await asyncio.wait_for(
+                        _discover_by_network_scan(self.hass, session),
+                        timeout=DISCOVERY_TIMEOUT_SECONDS,
                     )
-                    for info in devices:
-                        for device_id in info.device_ids:
-                            all_devices.append((info, device_id))
+                else:
+                    all_devices = await asyncio.wait_for(
+                        _discover_by_kospel_mac(session),
+                        timeout=DISCOVERY_TIMEOUT_SECONDS,
+                    )
 
             self._discovered_devices = all_devices
-            return self.async_show_progress_done(next_step_id="discover_result")
-        except Exception:
+            LOGGER.debug(
+                "Discovery completed via method=%s found_devices=%s",
+                self._discovery_method,
+                len(self._discovered_devices),
+            )
+        except asyncio.TimeoutError:
+            LOGGER.warning(
+                "Discovery timed out after %s seconds via method=%s",
+                DISCOVERY_TIMEOUT_SECONDS,
+                self._discovery_method,
+            )
             self._discovered_devices = []
-            return self.async_show_progress_done(next_step_id="discover_result")
+        except Exception:
+            LOGGER.exception("Discovery failed via method=%s", self._discovery_method)
+            self._discovered_devices = []
 
     async def async_step_discover(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Scan network for Kospel devices."""
+        LOGGER.warning(
+            "Discovery UI step entered (method=%s)",
+            self._discovery_method,
+        )
         if user_input and user_input.get("action") == "manual":
             return self.async_show_form(
                 step_id="http",
@@ -216,18 +393,44 @@ class KospelConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 ),
             )
 
-        progress_task = self.hass.async_create_task(self._async_run_discovery())
+        # Avoid progress-step edge cases when auto discovery has no DHCP candidates.
+        if (
+            self._discovery_method == "auto_discovery"
+            and not _DHCP_CANDIDATE_HOSTS
+            and self._discover_task is None
+        ):
+            LOGGER.info(
+                "Auto discovery has no DHCP candidates, showing result directly"
+            )
+            self._discovered_devices = []
+            return await self.async_step_discover_result()
+
+        if self._discover_task is None:
+            LOGGER.debug("Creating new discovery progress task")
+            self._discover_task = self.hass.async_create_task(self._async_run_discovery())
+        elif not self._discover_task.done():
+            LOGGER.debug("Reusing running discovery progress task")
+        else:
+            LOGGER.debug("Discovery progress task is done, moving to result step")
+            self._discover_task = None
+            return self.async_show_progress_done(next_step_id="discover_result")
         return self.async_show_progress(
             step_id="discover",
             progress_action="discover",
-            progress_task=progress_task,
+            progress_task=self._discover_task,
         )
 
     async def async_step_discover_result(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle discovery result: show device list or retry form."""
+        # Clear cached task only after progress step transitions to result.
+        self._discover_task = None
         if not self._discovered_devices:
+            LOGGER.debug(
+                "Discovery result empty for method=%s",
+                self._discovery_method,
+            )
             return self.async_show_form(
                 step_id="discover",
                 data_schema=vol.Schema(
@@ -252,6 +455,7 @@ class KospelConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             options[unique_id] = (
                 f"{info.host} — {info.serial_number} (dev {device_id}, {model})"
             )
+        LOGGER.debug("Discovery result offers %s selectable devices", len(options))
 
         return self.async_show_form(
             step_id="select_device",

--- a/custom_components/kospel/const.py
+++ b/custom_components/kospel/const.py
@@ -19,13 +19,9 @@ CONF_DEVICE_ID = "device_id"
 CONF_SERIAL_NUMBER = "serial_number"
 CONF_SIMULATION_MODE = "simulation_mode"  # Deprecated; used for migration only
 
-# Default subnets for discovery when Network integration returns none
-DEFAULT_SUBNETS = [
-    "192.168.1.0/24",
-    "192.168.0.0/24",
-    "192.168.101.0/24",
-    "10.0.0.0/24",
-]
+# Kospel S.A. MA-S prefix from IEEE registry / vendor lookup (36-bit).
+# Normalized format strips separators and uses lowercase hex.
+KOSPEL_MAC_PREFIXES = ("70b3d5249",)
 
 # Backend type values
 BACKEND_TYPE_HTTP = "http"

--- a/custom_components/kospel/manifest.json
+++ b/custom_components/kospel/manifest.json
@@ -6,6 +6,11 @@
   "documentation": "https://github.com/JanKrl/ha-kospel-cmi",
   "issue_tracker": "https://github.com/JanKrl/ha-kospel-cmi/issues",
   "dependencies": ["http", "network"],
+  "dhcp": [
+    {
+      "macaddress": "70B3D5*"
+    }
+  ],
   "requirements": [
     "aiohttp>=3.13.3",
     "kospel-cmi-lib==1.0.0b1"

--- a/custom_components/kospel/manifest.json
+++ b/custom_components/kospel/manifest.json
@@ -6,11 +6,6 @@
   "documentation": "https://github.com/JanKrl/ha-kospel-cmi",
   "issue_tracker": "https://github.com/JanKrl/ha-kospel-cmi/issues",
   "dependencies": ["http", "network"],
-  "dhcp": [
-    {
-      "macaddress": "70B3D5*"
-    }
-  ],
   "requirements": [
     "aiohttp>=3.13.3",
     "kospel-cmi-lib==1.0.0b1"

--- a/custom_components/kospel/strings.json
+++ b/custom_components/kospel/strings.json
@@ -7,14 +7,10 @@
   "config": {
     "step": {
       "user": {
-        "title": "Choose connection type",
-        "description": "Select how to connect: HTTP (real device) or YAML file (development). For YAML, state is stored in {yaml_path}.",
+        "title": "Choose connection method",
+        "description": "Select network scan, manual entry, or YAML mode for development.",
         "data": {
-          "backend_type": "Connection type"
-        },
-        "options": {
-          "option_http": "Heater (HTTP)",
-          "option_yaml": "File-based (development)"
+          "connection_mode": "Method"
         }
       },
       "http_method": {
@@ -44,7 +40,7 @@
         "title": "Select device",
         "description": "Choose the Kospel device to add.",
         "data": {
-          "device": "Device"
+          "device": "Found devices"
         }
       },
       "http": {

--- a/custom_components/kospel/strings.json
+++ b/custom_components/kospel/strings.json
@@ -19,12 +19,13 @@
       },
       "http_method": {
         "title": "Connection method",
-        "description": "Discover devices on your network or enter connection details manually.",
+        "description": "Choose automatic discovery by MAC candidates, full network scan, or manual entry.",
         "data": {
           "http_method": "Method"
         },
         "options": {
-          "option_discover": "Discover devices",
+          "option_auto_discovery": "Auto discovery (MAC candidates)",
+          "option_network_scan": "Network scan (all adapter subnets)",
           "option_manual": "Enter manually"
         }
       },
@@ -69,7 +70,8 @@
       "unknown": "Unexpected error occurred"
     },
     "abort": {
-      "already_configured": "Integration is already configured"
+      "already_configured": "Integration is already configured",
+      "not_kospel_device": "Discovered device does not match Kospel DHCP signature"
     },
     "options": {
       "step": {

--- a/custom_components/kospel/translations/pl.json
+++ b/custom_components/kospel/translations/pl.json
@@ -7,14 +7,10 @@
   "config": {
     "step": {
       "user": {
-        "title": "Wybierz typ po\u0142\u0105czenia",
-        "description": "Wybierz spos\u00f3b po\u0142\u0105czenia: HTTP (prawdziwe urz\u0105dzenie) lub plik YAML (rozw\u00f3j). W trybie YAML stan jest zapisywany w {yaml_path}.",
+        "title": "Wybierz metod\u0119 po\u0142\u0105czenia",
+        "description": "Wybierz skanowanie sieci, r\u0119czne wprowadzenie albo tryb YAML do rozwoju.",
         "data": {
-          "backend_type": "Typ po\u0142\u0105czenia"
-        },
-        "options": {
-          "option_http": "Grzejnik (HTTP)",
-          "option_yaml": "Plik (rozw\u00f3j)"
+          "connection_mode": "Metoda"
         }
       },
       "http_method": {
@@ -44,7 +40,7 @@
         "title": "Wybierz urz\u0105dzenie",
         "description": "Wybierz grzejnik Kospel do dodania.",
         "data": {
-          "device": "Urz\u0105dzenie"
+          "device": "Znalezione urz\u0105dzenia"
         }
       },
       "http": {

--- a/custom_components/kospel/translations/pl.json
+++ b/custom_components/kospel/translations/pl.json
@@ -19,12 +19,13 @@
       },
       "http_method": {
         "title": "Spos\u00f3b po\u0142\u0105czenia",
-        "description": "Wykryj urz\u0105dzenia w sieci lub wprowad\u017a dane r\u0119cznie.",
+        "description": "Wybierz automatyczne wykrywanie po MAC, pe\u0142ne skanowanie sieci albo wprowadzenie danych r\u0119cznie.",
         "data": {
           "http_method": "Metoda"
         },
         "options": {
-          "option_discover": "Wykryj urz\u0105dzenia",
+          "option_auto_discovery": "Automatyczne wykrywanie (kandydaci po MAC)",
+          "option_network_scan": "Skanowanie sieci (wszystkie podsieci adapter\u00f3w)",
           "option_manual": "Wprowad\u017a r\u0119cznie"
         }
       },
@@ -69,7 +70,8 @@
       "unknown": "Wyst\u0105pi\u0142 nieoczekiwany b\u0142\u0105d"
     },
     "abort": {
-      "already_configured": "Integracja jest ju\u017c skonfigurowana"
+      "already_configured": "Integracja jest ju\u017c skonfigurowana",
+      "not_kospel_device": "Wykryte urz\u0105dzenie nie pasuje do sygnatury DHCP Kospel"
     },
     "options": {
       "step": {

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -9,6 +9,9 @@ This page is for users who want deeper control, better diagnostics, or developme
 - Connects to a real Kospel module over LAN.
 - Uses heater IP and device ID selected in config flow.
 - Best choice for normal Home Assistant usage.
+- Note: MAC-based auto-discovery is currently hidden/disabled in UI due to
+  unresolved MAC-prefix mismatch observed on a real device. Network scan and
+  manual entry are the supported setup paths until discovery matching is revised.
 
 ### YAML backend (development mode)
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -79,7 +79,6 @@ from custom_components.kospel.const import (
     CONF_REFRESH_DELAY_AFTER_SET,
     CONF_SERIAL_NUMBER,
     DEFAULT_REFRESH_DELAY_AFTER_SET,
-    DEFAULT_SUBNETS,
     REFRESH_DELAY_MAX,
     REFRESH_DELAY_MIN,
     make_unique_id,
@@ -91,7 +90,12 @@ from custom_components.kospel.config_flow import (
     KospelConfigFlowHandler,
     KospelOptionsFlowHandler,
     validate_http_input,
+    _DHCP_CANDIDATE_HOSTS,
+    _discover_by_kospel_mac,
+    _discover_by_network_scan,
     _get_subnets_to_scan,
+    _is_kospel_mac,
+    _normalize_mac,
 )
 
 
@@ -214,8 +218,8 @@ class TestGetSubnetsToScan:
     """Tests for _get_subnets_to_scan."""
 
     @pytest.mark.asyncio
-    async def test_returns_default_subnets_when_network_fails(self) -> None:
-        """_get_subnets_to_scan returns DEFAULT_SUBNETS when network raises."""
+    async def test_returns_empty_when_network_fails(self) -> None:
+        """_get_subnets_to_scan returns empty when network raises."""
         hass = MagicMock()
         with patch(
             "custom_components.kospel.config_flow.network.async_get_adapters",
@@ -223,7 +227,7 @@ class TestGetSubnetsToScan:
             side_effect=Exception("Network not loaded"),
         ):
             result = await _get_subnets_to_scan(hass)
-        assert result == DEFAULT_SUBNETS
+        assert result == []
 
     @pytest.mark.asyncio
     async def test_returns_subnets_from_adapters(self) -> None:
@@ -258,11 +262,11 @@ class TestGetSubnetsToScan:
             return_value=adapters,
         ):
             result = await _get_subnets_to_scan(hass)
-        assert result == DEFAULT_SUBNETS
+        assert result == []
 
     @pytest.mark.asyncio
-    async def test_returns_default_when_no_ipv4(self) -> None:
-        """_get_subnets_to_scan returns DEFAULT_SUBNETS when no IPv4 addresses."""
+    async def test_returns_empty_when_no_ipv4(self) -> None:
+        """_get_subnets_to_scan returns empty when no IPv4 addresses."""
         hass = MagicMock()
         adapters = [{"enabled": True, "ipv4": []}]
         with patch(
@@ -271,7 +275,251 @@ class TestGetSubnetsToScan:
             return_value=adapters,
         ):
             result = await _get_subnets_to_scan(hass)
-        assert result == DEFAULT_SUBNETS
+        assert result == []
+
+
+class TestMacFilteringHelpers:
+    """Tests for MAC normalization and Kospel MAC filtering."""
+
+    def test_normalize_mac_removes_separators_and_lowercases(self) -> None:
+        """_normalize_mac returns lowercase hex string without separators."""
+        assert _normalize_mac("70:B3:D5:24:9A:BC") == "70b3d5249abc"
+
+    def test_is_kospel_mac_matches_registered_prefix(self) -> None:
+        """_is_kospel_mac returns True for known Kospel vendor prefix."""
+        assert _is_kospel_mac("70-B3-D5-24-9F-00")
+
+    def test_is_kospel_mac_rejects_other_vendors(self) -> None:
+        """_is_kospel_mac returns False for non-Kospel prefixes."""
+        assert not _is_kospel_mac("AA:BB:CC:DD:EE:FF")
+
+class TestDiscoverByKospelMac:
+    """Tests for discovery path using DHCP candidate hosts."""
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_dhcp_candidates(self) -> None:
+        """_discover_by_kospel_mac returns empty when no DHCP candidates exist."""
+        _DHCP_CANDIDATE_HOSTS.clear()
+        result = await _discover_by_kospel_mac(MagicMock())
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_discovers_from_dhcp_candidate_hosts(self) -> None:
+        """_discover_by_kospel_mac probes DHCP hosts and expands device IDs."""
+        _DHCP_CANDIDATE_HOSTS.clear()
+        _DHCP_CANDIDATE_HOSTS.update({"192.168.1.10"})
+        session = MagicMock()
+        discovered = MagicMock()
+        discovered.device_ids = [65, 66]
+
+        with patch(
+            "custom_components.kospel.config_flow.probe_device",
+            new_callable=AsyncMock,
+            return_value=discovered,
+        ) as mock_probe:
+            result = await _discover_by_kospel_mac(session)
+
+        mock_probe.assert_awaited_once_with(session, "192.168.1.10")
+        assert result == [(discovered, 65), (discovered, 66)]
+
+
+class TestConfigFlowDiscoveryFallback:
+    """Tests for config flow fallback behavior in discovery."""
+
+    @pytest.mark.asyncio
+    async def test_run_discovery_falls_back_to_subnet_scan(self) -> None:
+        """_async_run_discovery uses network scan when method is network_scan."""
+        handler = KospelConfigFlowHandler()
+        handler.hass = MagicMock()
+        handler._discovery_method = "network_scan"
+        handler.async_show_progress_done = lambda next_step_id: {
+            "type": "progress_done",
+            "next_step_id": next_step_id,
+        }
+
+        found = MagicMock()
+        found.device_ids = [65]
+
+        with patch(
+            "custom_components.kospel.config_flow._discover_by_network_scan",
+            new_callable=AsyncMock,
+            return_value=[(found, 65)],
+        ) as mock_discover:
+            result = await handler._async_run_discovery()
+
+        mock_discover.assert_awaited_once()
+        assert handler._discovered_devices == [(found, 65)]
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_discover_step_transitions_when_task_done(self) -> None:
+        """async_step_discover returns progress_done when task already finished."""
+        handler = KospelConfigFlowHandler()
+        handler.hass = MagicMock()
+        handler._discover_task = MagicMock()
+        handler._discover_task.done.return_value = True
+        handler.async_show_progress_done = lambda next_step_id: {
+            "type": "progress_done",
+            "next_step_id": next_step_id,
+        }
+
+        result = await handler.async_step_discover()
+
+        assert result == {"type": "progress_done", "next_step_id": "discover_result"}
+        assert handler._discover_task is None
+
+    @pytest.mark.asyncio
+    async def test_discover_result_with_no_devices_shows_manual_retry(self) -> None:
+        """async_step_discover_result shows no-devices form with manual/retry choices."""
+        handler = KospelConfigFlowHandler()
+        handler._discovered_devices = []
+        handler.async_show_form = lambda step_id, data_schema, errors=None: {
+            "type": "show_form",
+            "step_id": step_id,
+            "data_schema": data_schema,
+            "errors": errors,
+        }
+
+        result = await handler.async_step_discover_result()
+
+        assert result["type"] == "show_form"
+        assert result["step_id"] == "discover"
+        assert result["errors"] == {"base": "no_devices_found"}
+
+    @pytest.mark.asyncio
+    async def test_run_discovery_uses_auto_discovery_by_default(self) -> None:
+        """_async_run_discovery uses MAC candidate auto discovery by default."""
+        handler = KospelConfigFlowHandler()
+        handler.hass = MagicMock()
+        handler.async_show_progress_done = lambda next_step_id: {
+            "type": "progress_done",
+            "next_step_id": next_step_id,
+        }
+        found = MagicMock()
+        found.device_ids = [65]
+
+        with patch(
+            "custom_components.kospel.config_flow._discover_by_kospel_mac",
+            new_callable=AsyncMock,
+            return_value=[(found, 65)],
+        ) as mock_auto:
+            await handler._async_run_discovery()
+
+        mock_auto.assert_awaited_once()
+
+
+class TestDhcpDiscoveryStep:
+    """Tests for Home Assistant DHCP discovery flow step."""
+
+    @pytest.mark.asyncio
+    async def test_dhcp_ignores_non_kospel_mac(self) -> None:
+        """async_step_dhcp aborts for non-Kospel MAC addresses."""
+        handler = KospelConfigFlowHandler()
+        handler.async_abort = lambda reason: {"type": "abort", "reason": reason}
+        result = await handler.async_step_dhcp(
+            {"ip": "192.168.1.10", "macaddress": "AA:BB:CC:DD:EE:FF"}
+        )
+        assert result == {"type": "abort", "reason": "not_kospel_device"}
+
+    @pytest.mark.asyncio
+    async def test_dhcp_creates_entry_for_single_device(self) -> None:
+        """async_step_dhcp probes host and creates entry for single device ID."""
+        handler = KospelConfigFlowHandler()
+        _DHCP_CANDIDATE_HOSTS.clear()
+        info = MagicMock()
+        info.device_ids = [65]
+        info.serial_number = "mi01_123"
+        info.host = "192.168.1.10"
+        handler.async_create_entry = lambda title, data: {
+            "type": "create_entry",
+            "title": title,
+            "data": data,
+        }
+        handler.async_set_unique_id = AsyncMock()
+        handler._abort_if_unique_id_configured = MagicMock()
+
+        with patch(
+            "custom_components.kospel.config_flow.probe_device",
+            new_callable=AsyncMock,
+            return_value=info,
+        ):
+            result = await handler.async_step_dhcp(
+                {"ip": "192.168.1.10", "macaddress": "70:B3:D5:24:9A:CC"}
+            )
+
+        assert "192.168.1.10" in _DHCP_CANDIDATE_HOSTS
+        assert result["type"] == "create_entry"
+
+
+class TestDiscoverByNetworkScan:
+    """Tests for adapter-subnet network scan discovery."""
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_without_subnets(self) -> None:
+        """_discover_by_network_scan returns empty when no adapter subnets exist."""
+        with patch(
+            "custom_components.kospel.config_flow._get_subnets_to_scan",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            result = await _discover_by_network_scan(MagicMock(), MagicMock())
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_scans_all_subnets_and_expands_device_ids(self) -> None:
+        """_discover_by_network_scan scans all subnets from adapters."""
+        info = MagicMock()
+        info.device_ids = [65, 66]
+        with patch(
+            "custom_components.kospel.config_flow._get_subnets_to_scan",
+            new_callable=AsyncMock,
+            return_value=["192.168.1.0/24", "10.0.0.0/24"],
+        ), patch(
+            "custom_components.kospel.config_flow.discover_devices",
+            new_callable=AsyncMock,
+            side_effect=[[info], []],
+        ) as mock_discover:
+            result = await _discover_by_network_scan(MagicMock(), MagicMock())
+        assert mock_discover.await_count == 2
+        assert result == [(info, 65), (info, 66)]
+
+
+class TestHttpMethodSelection:
+    """Tests for explicit HTTP connection method selection."""
+
+    @pytest.mark.asyncio
+    async def test_http_method_selects_auto_discovery(self) -> None:
+        """Selecting auto_discovery stores method and continues to discover step."""
+        handler = KospelConfigFlowHandler()
+        with patch.object(
+            handler,
+            "async_step_discover",
+            new_callable=AsyncMock,
+            return_value={"type": "discover"},
+        ) as mock_step:
+            result = await handler.async_step_http_method(
+                {"http_method": "auto_discovery"}
+            )
+        assert handler._discovery_method == "auto_discovery"
+        mock_step.assert_awaited_once()
+        assert result == {"type": "discover"}
+
+    @pytest.mark.asyncio
+    async def test_http_method_selects_network_scan(self) -> None:
+        """Selecting network_scan stores method and continues to discover step."""
+        handler = KospelConfigFlowHandler()
+        with patch.object(
+            handler,
+            "async_step_discover",
+            new_callable=AsyncMock,
+            return_value={"type": "discover"},
+        ) as mock_step:
+            result = await handler.async_step_http_method(
+                {"http_method": "network_scan"}
+            )
+        assert handler._discovery_method == "network_scan"
+        mock_step.assert_awaited_once()
+        assert result == {"type": "discover"}
 
 
 class TestKospelOptionsFlowHandler:


### PR DESCRIPTION
## Summary

This PR refines the config flow UX and stabilizes discovery behavior.

- Closes/refines config flow work from [#42](https://github.com/JanKrl/ha-kospel-cmi/issues/42).
- Implements and iterates on MAC/network discovery flow from [#43](https://github.com/JanKrl/ha-kospel-cmi/issues/43), with current auto-discovery hidden from UI pending MAC-prefix verification on real devices.

### Config flow UX changes

- Reworked initial setup step to show exactly 3 user-facing options:
  - `Network scan`
  - `Manual entry`
  - `YAML (for development only)`
- Updated device selection label to be clearer:
  - EN: `Found devices`
  - PL: `Znalezione urządzenia`
- Kept auto-discovery implementation in code, but removed it from visible setup choices for now.

### Discovery reliability fixes

- Fixed progress task lifecycle in discovery flow to prevent repeated task recreation and stuck spinners.
- Added explicit done-transition behavior from progress to result step.
- Added guardrail for no-candidate auto-discovery to show result directly (no-progress edge case).
- Added network scan safeguards:
  - timeout for discovery execution,
  - skip oversized subnets,
  - better diagnostics for subnet resolution and failures.

### Discovery strategy (temporary decision)

- Removed DHCP matcher from `manifest.json` so DHCP-triggered flow is currently disabled.
- Added explicit code comments and docs note explaining why:
  - observed MAC-prefix mismatch on at least one real device,
  - auto-discovery remains in code for future re-enable after investigation.

### Localization updates

- Updated `strings.json` and `translations/pl.json` to align with the new flow and labels.

## Why

- Improve first-time setup clarity.
- Avoid confusing raw option keys/labels in UI.
- Eliminate spinner loops and unclear progress behavior.
- Keep discovery architecture ready for re-enable without losing work, while shipping a stable user-visible setup path.

## Test plan

- Run config flow tests:
  - `uv run python -m pytest tests/test_config_flow.py -v`
- Run full test suite:
  - `uv run python -m pytest tests/ -v`
- Manual verification in Home Assistant:
  - Start integration flow and verify the 3-option first step.
  - Validate `Network scan` returns discovered devices and proceeds to selection.
  - Validate `Manual entry` works with valid IP/device_id.
  - Validate `YAML (for development only)` creates YAML-backed entry.
  - Validate no progress-spinner loop when auto-discovery has no candidates (internal path).

## Notes for reviewers

- Auto-discovery code is intentionally retained but hidden from user flow.
- DHCP manifest discovery was intentionally removed in this iteration.
- Follow-up work should revisit MAC/OUI matching with real-device captures before re-enabling DHCP auto-discovery.
