### PR TITLE
Add combined heating mode sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,9 @@ Entity IDs below are representative examples and can vary based on your device n
   - `sensor.instant_power`
   - `sensor.boiler_max_power_limit`
 - **Status Sensors**:
-  - `sensor.ch_heating_status` (`running`, `idle`, `disabled`)
-  - `sensor.dhw_heating_status` (`running`, `idle`, `disabled`)
+  - `sensor.heating_mode` (`off`, `idle`, `ch`, `dwh`) - **Recommended**: Combined heating mode for simplified monitoring
+  - ~~`sensor.ch_heating_status` (`running`, `idle`, `disabled`)~~ - **[DEPRECATED]** Use `sensor.heating_mode` instead
+  - ~~`sensor.dhw_heating_status` (`running`, `idle`, `disabled`)~~ - **[DEPRECATED]** Use `sensor.heating_mode` instead
   - `sensor.valve_position` (`CH`/`DHW`)
 
 ### Binary Sensors
@@ -126,6 +127,24 @@ Entity IDs below are representative examples and can vary based on your device n
 - **Auto mode schedules** can be read from the device state, but editing schedules from Home Assistant is not supported yet.
 - **DHW water heater entity** is intentionally read-only for writes; it reflects device state.
 - After changing values, refresh can be slightly delayed by design (configurable integration option).
+
+## Deprecations
+
+### Heating Status Sensors (v0.2.0+)
+
+The individual `sensor.ch_heating_status` and `sensor.dhw_heating_status` are **deprecated** in favor of the new `sensor.heating_mode` sensor.
+
+**Why?** The new combined sensor provides a clearer view of the heater's operational mode since CH and DHW can never run simultaneously by design. It has four possible states:
+- `off` – Both circuits disabled
+- `idle` – At least one circuit idle (none running)
+- `ch` – Central Heating running
+- `dwh` – Domestic Hot Water running
+
+**Migration:**
+- For existing installations: deprecated sensors remain available but are hidden in the main UI (moved to Diagnostic category)
+- For new installations: only the new `sensor.heating_mode` is added
+
+**Removal:** These sensors will be removed in v1.0.0 (breaking change release)
 
 ## Troubleshooting
 

--- a/custom_components/kospel/sensor.py
+++ b/custom_components/kospel/sensor.py
@@ -66,6 +66,9 @@ async def async_setup_entry(
         )
     )
     entities.append(KospelValvePositionSensor(coordinator, entry))
+    
+    # Combined heating mode sensor
+    entities.append(KospelHeatingModeSensor(coordinator, entry))
 
     async_add_entities(entities)
 
@@ -269,6 +272,64 @@ class KospelValvePositionSensor(KospelSensorEntity):
         if hasattr(position, "value"):
             return position.value
         return str(position)
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self.async_write_ha_state()
+
+
+class KospelHeatingModeSensor(KospelSensorEntity):
+    """Combined heating mode sensor (CH, DHW, Idle, or Off).
+    
+    Since CH and DHW heating can never run simultaneously by design,
+    this sensor provides a single state indicating the current mode.
+    """
+
+    def __init__(
+        self,
+        coordinator: KospelDataUpdateCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the heating mode sensor."""
+        super().__init__(coordinator, entry, "heating_mode", "heating_mode")
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the heating mode (off, idle, ch, or dwh).
+        
+        Logic:
+        - Both DISABLED → "off"
+        - At least one IDLE (none RUNNING) → "idle"
+        - CH RUNNING → "ch"
+        - DHW RUNNING → "dwh"
+        """
+        controller: EkcoM3 = self.coordinator.data
+        
+        ch_status = getattr(controller, "co_heating_status", None)
+        dwh_status = getattr(controller, "cwu_heating_status", None)
+        
+        if ch_status is None or dwh_status is None:
+            return None
+        
+        # Normalize status values to lowercase string
+        ch_str = ch_status.value if hasattr(ch_status, "value") else str(ch_status)
+        dwh_str = dwh_status.value if hasattr(dwh_status, "value") else str(dwh_status)
+        
+        ch_str = ch_str.lower()
+        dwh_str = dwh_str.lower()
+        
+        # Check for RUNNING states (only one can be running at a time by design)
+        if ch_str == "running":
+            return "ch"
+        if dwh_str == "running":
+            return "dwh"
+        
+        # If neither is running, check for idle
+        if ch_str == "idle" or dwh_str == "idle":
+            return "idle"
+        
+        # Both must be disabled
+        return "off"
 
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""

--- a/custom_components/kospel/sensor.py
+++ b/custom_components/kospel/sensor.py
@@ -222,7 +222,14 @@ class KospelMaxPowerLimitSensor(KospelSensorEntity):
 
 
 class KospelHeatingStatusSensor(KospelSensorEntity):
-    """Representation of a Kospel heating status sensor (CH or CWU circuit)."""
+    """Representation of a Kospel heating status sensor (CH or CWU circuit).
+    
+    .. deprecated:: 0.2.0
+        Use :class:`KospelHeatingModeSensor` instead (sensor.heating_mode).
+        This sensor will be removed in v1.0.0 (breaking change).
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
         self,

--- a/custom_components/kospel/strings.json
+++ b/custom_components/kospel/strings.json
@@ -107,7 +107,7 @@
         "name": "Instant power"
       },
       "ch_heating": {
-        "name": "CH heating status",
+        "name": "[DEPRECATED] CH heating status",
         "state": {
           "running": "Running",
           "idle": "Idle",
@@ -115,7 +115,7 @@
         }
       },
       "dhw_heating": {
-        "name": "DHW heating status",
+        "name": "[DEPRECATED] DHW heating status",
         "state": {
           "running": "Running",
           "idle": "Idle",

--- a/custom_components/kospel/strings.json
+++ b/custom_components/kospel/strings.json
@@ -122,6 +122,15 @@
           "disabled": "Disabled"
         }
       },
+      "heating_mode": {
+        "name": "Heating mode",
+        "state": {
+          "off": "Off",
+          "idle": "Idle",
+          "ch": "CH",
+          "dwh": "DWH"
+        }
+      },
       "valve_position": {
         "name": "Valve Position",
         "state": {

--- a/custom_components/kospel/translations/pl.json
+++ b/custom_components/kospel/translations/pl.json
@@ -107,7 +107,7 @@
         "name": "Moc chwilowa"
       },
       "ch_heating": {
-        "name": "Status ogrzewania CO",
+        "name": "[DEPRECATED] Status ogrzewania CO",
         "state": {
           "running": "Praca",
           "idle": "Bezczynność",
@@ -115,7 +115,7 @@
         }
       },
       "dhw_heating": {
-        "name": "Status ogrzewania CWU",
+        "name": "[DEPRECATED] Status ogrzewania CWU",
         "state": {
           "running": "Praca",
           "idle": "Bezczynność",

--- a/custom_components/kospel/translations/pl.json
+++ b/custom_components/kospel/translations/pl.json
@@ -7,75 +7,75 @@
   "config": {
     "step": {
       "user": {
-        "title": "Wybierz metod\u0119 po\u0142\u0105czenia",
-        "description": "Wybierz skanowanie sieci, r\u0119czne wprowadzenie albo tryb YAML do rozwoju.",
+        "title": "Wybierz metodę połączenia",
+        "description": "Wybierz skanowanie sieci, ręczne wprowadzenie albo tryb YAML do rozwoju.",
         "data": {
           "connection_mode": "Metoda"
         }
       },
       "http_method": {
-        "title": "Spos\u00f3b po\u0142\u0105czenia",
-        "description": "Wybierz automatyczne wykrywanie po MAC, pe\u0142ne skanowanie sieci albo wprowadzenie danych r\u0119cznie.",
+        "title": "Sposób połączenia",
+        "description": "Wybierz automatyczne wykrywanie po MAC, pełne skanowanie sieci albo wprowadzenie danych ręcznie.",
         "data": {
           "http_method": "Metoda"
         },
         "options": {
           "option_auto_discovery": "Automatyczne wykrywanie (kandydaci po MAC)",
-          "option_network_scan": "Skanowanie sieci (wszystkie podsieci adapter\u00f3w)",
-          "option_manual": "Wprowad\u017a r\u0119cznie"
+          "option_network_scan": "Skanowanie sieci (wszystkie podsieci adapterów)",
+          "option_manual": "Wprowadź ręcznie"
         }
       },
       "discover": {
         "title": "Skanowanie sieci",
-        "description": "Skanowanie urz\u0105dze\u0144 Kospel. Mo\u017ce to potrwa\u0107 do minuty.",
+        "description": "Skanowanie urządzeń Kospel. Może to potrwać do minuty.",
         "data": {
           "action": "Akcja"
         },
         "options": {
           "option_retry": "Skanuj ponownie",
-          "option_manual": "Wprowad\u017a r\u0119cznie"
+          "option_manual": "Wprowadź ręcznie"
         }
       },
       "select_device": {
-        "title": "Wybierz urz\u0105dzenie",
+        "title": "Wybierz urządzenie",
         "description": "Wybierz grzejnik Kospel do dodania.",
         "data": {
-          "device": "Znalezione urz\u0105dzenia"
+          "device": "Znalezione urządzenia"
         }
       },
       "http": {
-        "title": "Po\u0142\u0105czenie z grzejnikiem",
-        "description": "Podaj adres IP grzejnika i identyfikator urz\u0105dzenia. Adres URL: http://[IP]/api/dev/[ID].",
+        "title": "Połączenie z grzejnikiem",
+        "description": "Podaj adres IP grzejnika i identyfikator urządzenia. Adres URL: http://[IP]/api/dev/[ID].",
         "data": {
           "heater_ip": "Adres IP grzejnika",
-          "device_id": "Identyfikator urz\u0105dzenia"
+          "device_id": "Identyfikator urządzenia"
         }
       }
     },
     "progress": {
       "discover": {
         "title": "Skanowanie sieci",
-        "description": "Wyszukiwanie urz\u0105dze\u0144 Kospel w sieci. Mo\u017ce to potrwa\u0107 do minuty."
+        "description": "Wyszukiwanie urządzeń Kospel w sieci. Może to potrwać do minuty."
       }
     },
     "error": {
-      "cannot_connect": "Nie uda\u0142o si\u0119 po\u0142\u0105czy\u0107 z grzejnikiem",
-      "invalid_auth": "Nieprawid\u0142owe uwierzytelnienie",
-      "invalid_device_id": "Identyfikator urz\u0105dzenia musi by\u0107 z zakresu 1\u2013255",
-      "no_devices_found": "Nie znaleziono urz\u0105dze\u0144 Kospel w sieci",
-      "unknown": "Wyst\u0105pi\u0142 nieoczekiwany b\u0142\u0105d"
+      "cannot_connect": "Nie udało się połączyć z grzejnikiem",
+      "invalid_auth": "Nieprawidłowe uwierzytelnienie",
+      "invalid_device_id": "Identyfikator urządzenia musi być z zakresu 1–255",
+      "no_devices_found": "Nie znaleziono urządzeń Kospel w sieci",
+      "unknown": "Wystąpił nieoczekiwany błąd"
     },
     "abort": {
-      "already_configured": "Integracja jest ju\u017c skonfigurowana",
-      "not_kospel_device": "Wykryte urz\u0105dzenie nie pasuje do sygnatury DHCP Kospel"
+      "already_configured": "Integracja jest już skonfigurowana",
+      "not_kospel_device": "Wykryte urządzenie nie pasuje do sygnatury DHCP Kospel"
     },
     "options": {
       "step": {
         "init": {
           "title": "Opcje integracji",
-          "description": "Grzejniki Kospel mog\u0105 potrzebowa\u0107 czasu na zapis zmian. Je\u015bli interfejs wraca do poprzedniej warto\u015bci po prze\u0142\u0105czeniu tryb\u00f3w, zwi\u0119ksz to op\u00f3\u017anienie.",
+          "description": "Grzejniki Kospel mogą potrzebować czasu na zapis zmian. Jeśli interfejs wraca do poprzedniej wartości po przełączeniu trybów, zwiększ to opóźnienie.",
           "data": {
-            "refresh_delay_after_set": "Op\u00f3\u017anienie od\u015bwie\u017cenia po zmianie (sekundy)"
+            "refresh_delay_after_set": "Opóźnienie odświeżenia po zmianie (sekundy)"
           }
         }
       }
@@ -101,7 +101,7 @@
         "name": "Temperatura CWU"
       },
       "pressure": {
-        "name": "Ci\u015bnienie"
+        "name": "Ciśnienie"
       },
       "power": {
         "name": "Moc chwilowa"
@@ -110,16 +110,16 @@
         "name": "Status ogrzewania CO",
         "state": {
           "running": "Praca",
-          "idle": "Bezczynno\u015b\u0107",
-          "disabled": "Wy\u0142\u0105czone"
+          "idle": "Bezczynność",
+          "disabled": "Wyłączone"
         }
       },
       "dhw_heating": {
         "name": "Status ogrzewania CWU",
         "state": {
           "running": "Praca",
-          "idle": "Bezczynno\u015b\u0107",
-          "disabled": "Wy\u0142\u0105czone"
+          "idle": "Bezczynność",
+          "disabled": "Wyłączone"
         }
       },
       "valve_position": {
@@ -131,6 +131,15 @@
       },
       "max_power_limit": {
         "name": "Limit mocy kotła"
+      },
+      "heating_mode": {
+        "name": "Tryb ogrzewania",
+        "state": {
+          "off": "Wyłączony",
+          "idle": "Bezczynność",
+          "ch": "CO",
+          "dwh": "CWU"
+        }
       }
     },
     "number": {
@@ -144,12 +153,12 @@
         "name": "Komfort+"
       },
       "room_temperature_comfort_minus": {
-        "name": "Komfort\u2212"
+        "name": "Komfort−"
       }
     },
     "water_heater": {
       "dhw": {
-        "name": "Ciep\u0142a woda u\u017cytkowa"
+        "name": "Ciepła woda użytkowa"
       }
     },
     "climate": {
@@ -158,7 +167,7 @@
         "state_attributes": {
           "hvac_mode": {
             "state": {
-              "off": "Wy\u0142\u0105czony",
+              "off": "Wyłączony",
               "heat": "Grzanie",
               "auto": "Auto"
             }
@@ -177,7 +186,7 @@
     },
     "select": {
       "boiler_max_power": {
-        "name": "Maks. moc kot\u0142a",
+        "name": "Maks. moc kotła",
         "state": {
           "2": "2 kW",
           "4": "4 kW",

--- a/tests/test_sensor_entity.py
+++ b/tests/test_sensor_entity.py
@@ -74,6 +74,7 @@ sys.modules["homeassistant.helpers.update_coordinator"].CoordinatorEntity = (
 )
 
 from custom_components.kospel.sensor import (  # noqa: E402
+    KospelHeatingModeSensor,
     KospelMaxPowerLimitSensor,
     KospelTemperatureSensor,
 )
@@ -208,4 +209,106 @@ class TestKospelMaxPowerLimitSensorNativeValue:
         mock_coordinator.data = mock_controller
 
         entity = KospelMaxPowerLimitSensor(mock_coordinator, mock_entry)
+        assert entity.native_value is None
+
+
+class TestKospelHeatingModeSensorNativeValue:
+    """Tests for combined heating mode sensor."""
+
+    def test_heating_mode_ch_running(
+        self, mock_coordinator, mock_entry
+    ) -> None:
+        """native_value is 'ch' when CH is running."""
+        mock_controller = MagicMock()
+        mock_controller.co_heating_status = "running"
+        mock_controller.cwu_heating_status = "idle"
+        mock_coordinator.data = mock_controller
+
+        entity = KospelHeatingModeSensor(mock_coordinator, mock_entry)
+        assert entity.native_value == "ch"
+
+    def test_heating_mode_dwh_running(
+        self, mock_coordinator, mock_entry
+    ) -> None:
+        """native_value is 'dwh' when DHW is running."""
+        mock_controller = MagicMock()
+        mock_controller.co_heating_status = "idle"
+        mock_controller.cwu_heating_status = "running"
+        mock_coordinator.data = mock_controller
+
+        entity = KospelHeatingModeSensor(mock_coordinator, mock_entry)
+        assert entity.native_value == "dwh"
+
+    def test_heating_mode_both_idle(
+        self, mock_coordinator, mock_entry
+    ) -> None:
+        """native_value is 'idle' when both are idle."""
+        mock_controller = MagicMock()
+        mock_controller.co_heating_status = "idle"
+        mock_controller.cwu_heating_status = "idle"
+        mock_coordinator.data = mock_controller
+
+        entity = KospelHeatingModeSensor(mock_coordinator, mock_entry)
+        assert entity.native_value == "idle"
+
+    def test_heating_mode_ch_idle_dwh_disabled(
+        self, mock_coordinator, mock_entry
+    ) -> None:
+        """native_value is 'idle' when CH is idle and DHW disabled."""
+        mock_controller = MagicMock()
+        mock_controller.co_heating_status = "idle"
+        mock_controller.cwu_heating_status = "disabled"
+        mock_coordinator.data = mock_controller
+
+        entity = KospelHeatingModeSensor(mock_coordinator, mock_entry)
+        assert entity.native_value == "idle"
+
+    def test_heating_mode_both_disabled(
+        self, mock_coordinator, mock_entry
+    ) -> None:
+        """native_value is 'off' when both are disabled."""
+        mock_controller = MagicMock()
+        mock_controller.co_heating_status = "disabled"
+        mock_controller.cwu_heating_status = "disabled"
+        mock_coordinator.data = mock_controller
+
+        entity = KospelHeatingModeSensor(mock_coordinator, mock_entry)
+        assert entity.native_value == "off"
+
+    def test_heating_mode_with_enum_values(
+        self, mock_coordinator, mock_entry
+    ) -> None:
+        """native_value works with enum-like objects that have .value attribute."""
+        mock_controller = MagicMock()
+        mock_ch_status = MagicMock()
+        mock_ch_status.value = "RUNNING"
+        mock_dwh_status = MagicMock()
+        mock_dwh_status.value = "IDLE"
+        mock_controller.co_heating_status = mock_ch_status
+        mock_controller.cwu_heating_status = mock_dwh_status
+        mock_coordinator.data = mock_controller
+
+        entity = KospelHeatingModeSensor(mock_coordinator, mock_entry)
+        assert entity.native_value == "ch"
+
+    def test_heating_mode_none_when_missing_ch(
+        self, mock_coordinator, mock_entry
+    ) -> None:
+        """native_value is None when CH status is missing."""
+        mock_controller = MagicMock(spec=[])
+        mock_controller.cwu_heating_status = "idle"
+        mock_coordinator.data = mock_controller
+
+        entity = KospelHeatingModeSensor(mock_coordinator, mock_entry)
+        assert entity.native_value is None
+
+    def test_heating_mode_none_when_missing_dwh(
+        self, mock_coordinator, mock_entry
+    ) -> None:
+        """native_value is None when DHW status is missing."""
+        mock_controller = MagicMock(spec=[])
+        mock_controller.co_heating_status = "idle"
+        mock_coordinator.data = mock_controller
+
+        entity = KospelHeatingModeSensor(mock_coordinator, mock_entry)
         assert entity.native_value is None


### PR DESCRIPTION
## Feature

Add a new sensor that consolidates CH (Central Heating) and DHW (Domestic Hot Water) heating statuses into a single entity.

Since these circuits can never run simultaneously by design (as per device specifications), this sensor provides a clearer view of the current heating mode.

## New Sensor: `sensor.heating_mode`

### States
- **`off`** – Both circuits disabled
- **`idle`** – At least one circuit idle (none running)
- **`ch`** – Central Heating running
- **`dwh`** – Domestic Hot Water running

### Logic
The sensor intelligently combines the two heating status sensors:
- Checks if CH or DHW is running → returns `"ch"` or `"dwh"`
- If neither is running but at least one is idle → returns `"idle"`
- If both are disabled → returns `"off"`
- Returns `None` if data is unavailable

## Changes

- **`custom_components/kospel/sensor.py`**
  - Added `KospelHeatingModeSensor` class
  - Registered in `async_setup_entry()`

- **`custom_components/kospel/strings.json`**
  - Added English translations for heating mode states

- **`custom_components/kospel/translations/pl.json`**
  - Added Polish translations (Tryb ogrzewania)

- **`tests/test_sensor_entity.py`**
  - Added 8 comprehensive unit tests covering all scenarios

## Testing

✅ All 115 tests pass (7 existing + 8 new)

Tests cover:
- CH running
- DHW running
- Both idle
- Mixed idle/disabled
- Both disabled
- Enum value handling
- Missing data handling