### PR TITLE
Add DWH temp setting entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,53 +10,6 @@ Control and monitor compatible Kospel electric heaters from Home Assistant using
 > This is an unofficial, community-maintained integration and is not affiliated with or endorsed by Kospel.
 > Use it at your own responsibility.
 
-## Capabilities
-
-This integration allows you to:
-
-- **Control central heating from a single climate entity**:
-  - Set HVAC mode: `off`, `heat`, `auto`.
-  - Use presets in auto mode: `winter`, `summer`, `party`, `vacation`.
-  - Adjust target temperature in manual heat mode.
-- **Monitor key operating values**:
-  - CH and DHW temperatures.
-  - CH and DHW target temperatures.
-  - Instant power and pressure.
-  - CH/DHW heating status and valve position.
-- **Manage selected configuration values**:
-  - Room preset temperatures (`eco`, `comfort`, `comfort+`, `comfort-`).
-  - Maximum boiler power step (`2`, `4`, `6`, `8` kW).
-- **Track connectivity and DHW state**:
-  - Online/offline connectivity status.
-  - Dedicated domestic hot water entity with current and target temperature attributes.
-
-## Installation (HACS)
-
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=JanKrl&repository=ha-kospel-cmi&category=integration)
-
-Manual HACS steps:
-
-1. Open **HACS** -> **Integrations** -> **three-dot menu** -> **Custom repositories**.
-2. Add repository URL: `https://github.com/JanKrl/ha-kospel-cmi`.
-3. Category: **Integration**.
-4. Install **Kospel Electric Heaters** from HACS.
-5. Restart Home Assistant.
-6. Go to **Settings** -> **Devices & Services** -> **Add Integration** -> **Kospel Electric Heaters**.
-
-## First-Time Setup
-
-When adding the integration in Home Assistant:
-
-- Choose **Discover** to scan your network for compatible devices, or
-- choose **Manual** and enter heater IP + device ID.
-
-## Requirements
-
-- Home Assistant `2024.1+` with support for custom integrations (HACS recommended).
-- Your Home Assistant instance must be able to reach the heater in your local network.
-- The integration works on older Home Assistant versions too; `2026.3+` only improves branding (custom icon/logo in UI).
-- To show branded icons/logos on older Home Assistant versions, integration assets must be added to the [Home Assistant brands repository](https://github.com/home-assistant/brands).
-
 ## Supported Devices
 
 - **EKCO.M3**.
@@ -129,23 +82,32 @@ Entity IDs below are representative examples and can vary based on your device n
 - **DHW water heater entity** is intentionally read-only for writes; it reflects device state.
 - After changing values, refresh can be slightly delayed by design (configurable integration option).
 
-## Deprecations
+## Installation (HACS)
 
-### Heating Status Sensors (v0.2.0+)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=JanKrl&repository=ha-kospel-cmi&category=integration)
 
-The individual `sensor.ch_heating_status` and `sensor.dhw_heating_status` are **deprecated** in favor of the new `sensor.heating_mode` sensor.
+Manual HACS steps:
 
-**Why?** The new combined sensor provides a clearer view of the heater's operational mode since CH and DHW can never run simultaneously by design. It has four possible states:
-- `off` – Both circuits disabled
-- `idle` – At least one circuit idle (none running)
-- `ch` – Central Heating running
-- `dwh` – Domestic Hot Water running
+1. Open **HACS** -> **Integrations** -> **three-dot menu** -> **Custom repositories**.
+2. Add repository URL: `https://github.com/JanKrl/ha-kospel-cmi`.
+3. Category: **Integration**.
+4. Install **Kospel Electric Heaters** from HACS.
+5. Restart Home Assistant.
+6. Go to **Settings** -> **Devices & Services** -> **Add Integration** -> **Kospel Electric Heaters**.
 
-**Migration:**
-- For existing installations: deprecated sensors remain available but are hidden in the main UI (moved to Diagnostic category)
-- For new installations: only the new `sensor.heating_mode` is added
+## First-Time Setup
 
-**Removal:** These sensors will be removed in v1.0.0 (breaking change release)
+When adding the integration in Home Assistant:
+
+- Choose **Discover** to scan your network for compatible devices, or
+- choose **Manual** and enter heater IP + device ID.
+
+## Requirements
+
+- Home Assistant `2024.1+` with support for custom integrations (HACS recommended).
+- Your Home Assistant instance must be able to reach the heater in your local network.
+- The integration works on older Home Assistant versions too; `2026.3+` only improves branding (custom icon/logo in UI).
+- To show branded icons/logos on older Home Assistant versions, integration assets must be added to the [Home Assistant brands repository](https://github.com/home-assistant/brands).
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ Entity IDs below are representative examples and can vary based on your device n
   - `number.comfort`
   - `number.comfort_plus`
   - `number.comfort_minus`
+- **DHW Preset Temperature Entities**:
+  - `number.dhw_eco`
+  - `number.dhw_comfort`
 
 ### Select (Configuration)
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Entity IDs below are representative examples and can vary based on your device n
 ### Water Heater
 
 - **Water Heater Entity**: `water_heater.domestic_hot_water`
-  - **Purpose**: DHW state visualization
+  - **Modes**: Controlled by climate preset modes
   - **Attributes**:
     - Current water temperature
     - Target DHW temperature
@@ -87,41 +87,39 @@ Entity IDs below are representative examples and can vary based on your device n
 ### Sensors
 
 - **Temperature and Setpoint Sensors**:
-  - `sensor.ch_temperature`
-  - `sensor.dhw_temperature`
-  - `sensor.ch_target_temperature`
-  - `sensor.dhw_target_temperature`
+  - Central heating (CH) current temperature
+  - Domestic water heating (DWH) current temperature
+  - CH target temperature
+  - DWH target temperature
+  - Outside temperature
 - **System Sensors**:
-  - `sensor.pressure`
-  - `sensor.instant_power`
-  - `sensor.boiler_max_power_limit`
-- **Status Sensors**:
-  - `sensor.heating_mode` (`off`, `idle`, `ch`, `dwh`) - **Recommended**: Combined heating mode for simplified monitoring
-  - ~~`sensor.ch_heating_status` (`running`, `idle`, `disabled`)~~ - **[DEPRECATED]** Use `sensor.heating_mode` instead
-  - ~~`sensor.dhw_heating_status` (`running`, `idle`, `disabled`)~~ - **[DEPRECATED]** Use `sensor.heating_mode` instead
-  - `sensor.valve_position` (`CH`/`DHW`)
+  - System pressure
+  - Current power consumption
+  - Valve position CO / DWH
+  - Heating mode CO / DWH
 
 ### Binary Sensors
 
 - **Connectivity Sensor**:
-  - `binary_sensor.connectivity`
+  - Connectivity
 
 ### Number (Configuration)
 
 - **Room Preset Temperature Entities**:
-  - `number.eco`
-  - `number.comfort`
-  - `number.comfort_plus`
-  - `number.comfort_minus`
+  - Economy
+  - Comfort
+  - Comfort+
+  - Comfort-
 - **DHW Preset Temperature Entities**:
-  - `number.dhw_eco`
-  - `number.dhw_comfort`
+  - Eco
+  - Comfort
+- **Limit Entities**:
+  - Outside temperature switch threshold
 
 ### Select (Configuration)
 
 - **Max Boiler Power Entity**:
-  - `select.max_boiler_power`
-  - Available options: `2 kW`, `4 kW`, `6 kW`, `8 kW`
+  - Limit device power to: `2 kW`, `4 kW`, `6 kW`, `8 kW`
 
 ## How To Use (Important Notes)
 

--- a/custom_components/kospel/manifest.json
+++ b/custom_components/kospel/manifest.json
@@ -8,7 +8,7 @@
   "dependencies": ["http", "network"],
   "requirements": [
     "aiohttp>=3.13.3",
-    "kospel-cmi-lib>=1.0.0,<2.0.0"
+    "kospel-cmi-lib>=1.0.2,<2.0.0"
   ],
   "codeowners": ["@JanKrl"],
   "integration_type": "hub",

--- a/custom_components/kospel/number.py
+++ b/custom_components/kospel/number.py
@@ -23,7 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 ROOM_PRESET_TEMP_MIN = 10.0
 ROOM_PRESET_TEMP_MAX = 25.0
 DHW_PRESET_TEMP_MIN = 30.0
-DHW_PRESET_TEMP_MAX = 65.0
+DHW_PRESET_TEMP_MAX = 80.0
 PRESET_TEMP_STEP = 0.1
 
 # (translation_key / controller property name / async setter name / min temp / max temp)

--- a/custom_components/kospel/number.py
+++ b/custom_components/kospel/number.py
@@ -1,4 +1,4 @@
-"""Number entities for Kospel integration (room preset temperatures)."""
+"""Number entities for Kospel integration (room and DHW preset temperatures)."""
 
 import asyncio
 import logging
@@ -22,14 +22,54 @@ _LOGGER = logging.getLogger(__name__)
 
 ROOM_PRESET_TEMP_MIN = 10.0
 ROOM_PRESET_TEMP_MAX = 25.0
-ROOM_PRESET_TEMP_STEP = 0.1
+DHW_PRESET_TEMP_MIN = 30.0
+DHW_PRESET_TEMP_MAX = 65.0
+PRESET_TEMP_STEP = 0.1
 
-# (translation_key / unique_id suffix / EkcoM3 property name, async setter name)
-_ROOM_PRESET_ENTITIES: list[tuple[str, str]] = [
-    ("room_temperature_economy", "set_room_temperature_economy"),
-    ("room_temperature_comfort", "set_room_temperature_comfort"),
-    ("room_temperature_comfort_plus", "set_room_temperature_comfort_plus"),
-    ("room_temperature_comfort_minus", "set_room_temperature_comfort_minus"),
+# (translation_key / controller property name / async setter name / min temp / max temp)
+_PRESET_ENTITIES: list[tuple[str, str, str, float, float]] = [
+    (
+        "room_temperature_economy",
+        "room_temperature_economy",
+        "set_room_temperature_economy",
+        ROOM_PRESET_TEMP_MIN,
+        ROOM_PRESET_TEMP_MAX,
+    ),
+    (
+        "room_temperature_comfort",
+        "room_temperature_comfort",
+        "set_room_temperature_comfort",
+        ROOM_PRESET_TEMP_MIN,
+        ROOM_PRESET_TEMP_MAX,
+    ),
+    (
+        "room_temperature_comfort_plus",
+        "room_temperature_comfort_plus",
+        "set_room_temperature_comfort_plus",
+        ROOM_PRESET_TEMP_MIN,
+        ROOM_PRESET_TEMP_MAX,
+    ),
+    (
+        "room_temperature_comfort_minus",
+        "room_temperature_comfort_minus",
+        "set_room_temperature_comfort_minus",
+        ROOM_PRESET_TEMP_MIN,
+        ROOM_PRESET_TEMP_MAX,
+    ),
+    (
+        "dhw_temperature_economy",
+        "cwu_temperature_economy",
+        "set_water_economy_temperature",
+        DHW_PRESET_TEMP_MIN,
+        DHW_PRESET_TEMP_MAX,
+    ),
+    (
+        "dhw_temperature_comfort",
+        "cwu_temperature_comfort",
+        "set_water_comfort_temperature",
+        DHW_PRESET_TEMP_MIN,
+        DHW_PRESET_TEMP_MAX,
+    ),
 ]
 
 
@@ -41,16 +81,24 @@ async def async_setup_entry(
     """Set up Kospel number entities."""
     coordinator: KospelDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     entities: list[NumberEntity] = [
-        KospelRoomPresetNumberEntity(coordinator, entry, prop_key, setter_name)
-        for prop_key, setter_name in _ROOM_PRESET_ENTITIES
+        KospelPresetNumberEntity(
+            coordinator,
+            entry,
+            translation_key,
+            value_attr,
+            setter_name,
+            min_temp,
+            max_temp,
+        )
+        for translation_key, value_attr, setter_name, min_temp, max_temp in _PRESET_ENTITIES
     ]
     async_add_entities(entities)
 
 
-class KospelRoomPresetNumberEntity(
+class KospelPresetNumberEntity(
     CoordinatorEntity[KospelDataUpdateCoordinator], NumberEntity
 ):
-    """Room preset temperature (economy / comfort / ±) as a read/write number.
+    """Preset temperature (room / DHW) as a read/write number.
 
     Shown under device **Configuration** with other system-style setpoints
     (e.g. max boiler power select).
@@ -58,32 +106,41 @@ class KospelRoomPresetNumberEntity(
 
     _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.CONFIG
-    _attr_native_min_value = ROOM_PRESET_TEMP_MIN
-    _attr_native_max_value = ROOM_PRESET_TEMP_MAX
-    _attr_native_step = ROOM_PRESET_TEMP_STEP
     _attr_device_class = NumberDeviceClass.TEMPERATURE
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+    _attr_native_step = PRESET_TEMP_STEP
 
     def __init__(
         self,
         coordinator: KospelDataUpdateCoordinator,
         entry: ConfigEntry,
+        translation_key: str,
         value_attr: str,
         setter_name: str,
+        min_temp: float,
+        max_temp: float,
+        step: float = PRESET_TEMP_STEP,
     ) -> None:
-        """Initialize the room preset number entity.
+        """Initialize the preset temperature number entity.
 
         Args:
             coordinator: Data update coordinator.
             entry: Config entry (device info and refresh delay options).
-            value_attr: EkcoM3 property name (same as translation_key / unique suffix).
-            setter_name: Name of the async setter on EkcoM3 (e.g. set_room_temperature_economy).
+            translation_key: Translation key used for human-friendly entity naming.
+            value_attr: EkcoM3 property name to read from the controller.
+            setter_name: Name of the async setter on EkcoM3.
+            min_temp: Minimum supported temperature for this preset.
+            max_temp: Maximum supported temperature for this preset.
+            step: Supported step size for this preset.
         """
         super().__init__(coordinator)
         device_id = get_device_identifier(entry)
         self._attr_unique_id = f"{device_id}_{value_attr}"
-        self._attr_translation_key = value_attr
+        self._attr_translation_key = translation_key
         self._attr_device_info = get_device_info(entry)
+        self._attr_native_min_value = min_temp
+        self._attr_native_max_value = max_temp
+        self._attr_native_step = step
         self._value_attr = value_attr
         self._setter_name = setter_name
 

--- a/custom_components/kospel/number.py
+++ b/custom_components/kospel/number.py
@@ -24,6 +24,8 @@ ROOM_PRESET_TEMP_MIN = 10.0
 ROOM_PRESET_TEMP_MAX = 25.0
 DHW_PRESET_TEMP_MIN = 30.0
 DHW_PRESET_TEMP_MAX = 80.0
+OUTSIDE_THRESHOLD_MIN = 0
+OUTSIDE_THRESHOLD_MAX = 30
 PRESET_TEMP_STEP = 0.1
 
 # (translation_key / controller property name / async setter name / min temp / max temp)
@@ -70,6 +72,13 @@ _PRESET_ENTITIES: list[tuple[str, str, str, float, float]] = [
         DHW_PRESET_TEMP_MIN,
         DHW_PRESET_TEMP_MAX,
     ),
+    (
+        "outside_temperature_off",
+        "outside_temperature_off",
+        "set_outside_temperature_off",
+        OUTSIDE_THRESHOLD_MIN,
+        OUTSIDE_THRESHOLD_MAX,
+    )
 ]
 
 

--- a/custom_components/kospel/number.py
+++ b/custom_components/kospel/number.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 
-from homeassistant.components.number import NumberDeviceClass, NumberEntity
+from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
@@ -109,6 +109,7 @@ class KospelPresetNumberEntity(
     _attr_device_class = NumberDeviceClass.TEMPERATURE
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_native_step = PRESET_TEMP_STEP
+    _attr_mode = NumberMode.BOX
 
     def __init__(
         self,

--- a/custom_components/kospel/sensor.py
+++ b/custom_components/kospel/sensor.py
@@ -35,6 +35,7 @@ async def async_setup_entry(
         ("supply_setpoint", "supply_setpoint"),
         ("room_temperature", "room_temperature"),
         ("water_temperature", "water_current_temperature"),
+        ("outside_temperature", "outside_temperature"),
     ]
 
     for unique_id_suffix, attr_name in temperature_sensors:

--- a/custom_components/kospel/strings.json
+++ b/custom_components/kospel/strings.json
@@ -100,6 +100,9 @@
       "water_temperature": {
         "name": "DHW temperature"
       },
+      "outside_temperature": {
+        "name": "Outside temperature"
+      },
       "pressure": {
         "name": "Pressure"
       },
@@ -160,6 +163,9 @@
       },
       "dhw_temperature_comfort": {
         "name": "DHW Comfort"
+      },
+      "outside_temperature_off": {
+        "name": "Outside temperature switch off threshold"
       }
     },
     "water_heater": {

--- a/custom_components/kospel/strings.json
+++ b/custom_components/kospel/strings.json
@@ -154,6 +154,12 @@
       },
       "room_temperature_comfort_minus": {
         "name": "Comfort\u2212"
+      },
+      "dhw_temperature_economy": {
+        "name": "DHW Eco"
+      },
+      "dhw_temperature_comfort": {
+        "name": "DHW Comfort"
       }
     },
     "water_heater": {

--- a/custom_components/kospel/translations/pl.json
+++ b/custom_components/kospel/translations/pl.json
@@ -100,6 +100,9 @@
       "water_temperature": {
         "name": "Temperatura CWU"
       },
+      "outside_temperature": {
+        "name": "Temperatura zewnętrzna"
+      },
       "pressure": {
         "name": "Ciśnienie"
       },
@@ -160,6 +163,9 @@
       },
       "dhw_temperature_comfort": {
         "name": "CWU Komfort"
+      },
+      "outside_temperature_off": {
+        "name": "Limit temperatury zewnętrznej do wyłączenia"
       }
     },
     "water_heater": {

--- a/custom_components/kospel/translations/pl.json
+++ b/custom_components/kospel/translations/pl.json
@@ -154,6 +154,12 @@
       },
       "room_temperature_comfort_minus": {
         "name": "Komfort−"
+      },
+      "dhw_temperature_economy": {
+        "name": "CWU Eko"
+      },
+      "dhw_temperature_comfort": {
+        "name": "CWU Komfort"
       }
     },
     "water_heater": {

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -42,6 +42,8 @@ This page is for users who want deeper control, better diagnostics, or developme
 
 - `number` entities expose room preset temperatures:
   - economy, comfort, comfort+, comfort-
+- `number` entities also expose DHW preset temperatures:
+  - economy, comfort
 - `select` entity exposes boiler max power step:
   - power steps are device-specific,
   - `2`, `4`, `6`, `8` kW steps are for **EKCO.M3**.

--- a/tests/test_number_entity.py
+++ b/tests/test_number_entity.py
@@ -171,7 +171,7 @@ class TestKospelPresetNumberEntity:
         assert entity.native_step == PRESET_TEMP_STEP == 0.1
 
     def test_dhw_temperature_bounds(self, mock_coordinator, mock_entry) -> None:
-        """DHW preset entities expose 30–65 °C range."""
+        """DHW preset entities expose 30–80 °C range."""
         entity = KospelPresetNumberEntity(
             mock_coordinator,
             mock_entry,
@@ -183,7 +183,7 @@ class TestKospelPresetNumberEntity:
         )
 
         assert entity.native_min_value == DHW_PRESET_TEMP_MIN == 30.0
-        assert entity.native_max_value == DHW_PRESET_TEMP_MAX == 65.0
+        assert entity.native_max_value == DHW_PRESET_TEMP_MAX == 80.0
         assert entity.native_step == PRESET_TEMP_STEP == 0.1
 
     def test_entity_category_is_config(self, mock_coordinator, mock_entry) -> None:

--- a/tests/test_number_entity.py
+++ b/tests/test_number_entity.py
@@ -83,10 +83,12 @@ sys.modules["homeassistant.helpers.update_coordinator"].CoordinatorEntity = (
 )
 
 from custom_components.kospel.number import (  # noqa: E402
-    KospelRoomPresetNumberEntity,
+    KospelPresetNumberEntity,
+    DHW_PRESET_TEMP_MAX,
+    DHW_PRESET_TEMP_MIN,
+    PRESET_TEMP_STEP,
     ROOM_PRESET_TEMP_MAX,
     ROOM_PRESET_TEMP_MIN,
-    ROOM_PRESET_TEMP_STEP,
 )
 
 
@@ -110,7 +112,7 @@ def mock_coordinator(mock_entry):
     return coordinator
 
 
-class TestKospelRoomPresetNumberEntity:
+class TestKospelPresetNumberEntity:
     """Tests for native value, bounds, and async_set_native_value."""
 
     def test_native_value_reads_controller_property(
@@ -121,11 +123,14 @@ class TestKospelRoomPresetNumberEntity:
         mock_controller.room_temperature_economy = 20.5
         mock_coordinator.data = mock_controller
 
-        entity = KospelRoomPresetNumberEntity(
+        entity = KospelPresetNumberEntity(
             mock_coordinator,
             mock_entry,
             "room_temperature_economy",
+            "room_temperature_economy",
             "set_room_temperature_economy",
+            ROOM_PRESET_TEMP_MIN,
+            ROOM_PRESET_TEMP_MAX,
         )
 
         assert entity.native_value == 20.5
@@ -137,35 +142,60 @@ class TestKospelRoomPresetNumberEntity:
         mock_controller = object()
         mock_coordinator.data = mock_controller
 
-        entity = KospelRoomPresetNumberEntity(
+        entity = KospelPresetNumberEntity(
             mock_coordinator,
             mock_entry,
             "room_temperature_economy",
+            "room_temperature_economy",
             "set_room_temperature_economy",
+            ROOM_PRESET_TEMP_MIN,
+            ROOM_PRESET_TEMP_MAX,
         )
 
         assert entity.native_value is None
 
     def test_temperature_bounds_and_step(self, mock_coordinator, mock_entry) -> None:
         """Entity exposes 10–25 °C range and 0.1 step (matches module constants)."""
-        entity = KospelRoomPresetNumberEntity(
+        entity = KospelPresetNumberEntity(
             mock_coordinator,
             mock_entry,
             "room_temperature_comfort",
+            "room_temperature_comfort",
             "set_room_temperature_comfort",
+            ROOM_PRESET_TEMP_MIN,
+            ROOM_PRESET_TEMP_MAX,
         )
 
         assert entity.native_min_value == ROOM_PRESET_TEMP_MIN == 10.0
         assert entity.native_max_value == ROOM_PRESET_TEMP_MAX == 25.0
-        assert entity.native_step == ROOM_PRESET_TEMP_STEP == 0.1
+        assert entity.native_step == PRESET_TEMP_STEP == 0.1
+
+    def test_dhw_temperature_bounds(self, mock_coordinator, mock_entry) -> None:
+        """DHW preset entities expose 30–65 °C range."""
+        entity = KospelPresetNumberEntity(
+            mock_coordinator,
+            mock_entry,
+            "dhw_temperature_economy",
+            "cwu_temperature_economy",
+            "set_water_economy_temperature",
+            DHW_PRESET_TEMP_MIN,
+            DHW_PRESET_TEMP_MAX,
+        )
+
+        assert entity.native_min_value == DHW_PRESET_TEMP_MIN == 30.0
+        assert entity.native_max_value == DHW_PRESET_TEMP_MAX == 65.0
+        assert entity.native_step == PRESET_TEMP_STEP == 0.1
 
     def test_entity_category_is_config(self, mock_coordinator, mock_entry) -> None:
         """Room presets appear under device Configuration (with max boiler power)."""
-        entity = KospelRoomPresetNumberEntity(
+        entity = KospelPresetNumberEntity(
             mock_coordinator,
             mock_entry,
             "room_temperature_economy",
+            "room_temperature_economy",
             "set_room_temperature_economy",
+            ROOM_PRESET_TEMP_MIN,
+            ROOM_PRESET_TEMP_MAX,
         )
         assert entity._attr_entity_category == "config"
 
@@ -180,11 +210,14 @@ class TestKospelRoomPresetNumberEntity:
         mock_coordinator.data = mock_controller
         mock_coordinator.async_request_refresh = AsyncMock()
 
-        entity = KospelRoomPresetNumberEntity(
+        entity = KospelPresetNumberEntity(
             mock_coordinator,
             mock_entry,
             "room_temperature_economy",
+            "room_temperature_economy",
             "set_room_temperature_economy",
+            ROOM_PRESET_TEMP_MIN,
+            ROOM_PRESET_TEMP_MAX,
         )
 
         with patch(
@@ -197,12 +230,14 @@ class TestKospelRoomPresetNumberEntity:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        ("translation_key", "setter_name"),
+        ("translation_key", "setter_name", "value_attr"),
         [
-            ("room_temperature_economy", "set_room_temperature_economy"),
-            ("room_temperature_comfort", "set_room_temperature_comfort"),
-            ("room_temperature_comfort_plus", "set_room_temperature_comfort_plus"),
-            ("room_temperature_comfort_minus", "set_room_temperature_comfort_minus"),
+            ("room_temperature_economy", "set_room_temperature_economy", "room_temperature_economy"),
+            ("room_temperature_comfort", "set_room_temperature_comfort", "room_temperature_comfort"),
+            ("room_temperature_comfort_plus", "set_room_temperature_comfort_plus", "room_temperature_comfort_plus"),
+            ("room_temperature_comfort_minus", "set_room_temperature_comfort_minus", "room_temperature_comfort_minus"),
+            ("dhw_temperature_economy", "set_water_economy_temperature", "cwu_temperature_economy"),
+            ("dhw_temperature_comfort", "set_water_comfort_temperature", "cwu_temperature_comfort"),
         ],
     )
     async def test_each_preset_uses_matching_setter(
@@ -211,21 +246,30 @@ class TestKospelRoomPresetNumberEntity:
         mock_entry,
         translation_key: str,
         setter_name: str,
+        value_attr: str,
     ) -> None:
         """Each preset entity calls its corresponding EkcoM3 setter."""
         mock_controller = MagicMock()
-        for _key, _setter in [
-            ("room_temperature_economy", "set_room_temperature_economy"),
-            ("room_temperature_comfort", "set_room_temperature_comfort"),
-            ("room_temperature_comfort_plus", "set_room_temperature_comfort_plus"),
-            ("room_temperature_comfort_minus", "set_room_temperature_comfort_minus"),
+        for _key, _setter, _value_attr in [
+            ("room_temperature_economy", "set_room_temperature_economy", "room_temperature_economy"),
+            ("room_temperature_comfort", "set_room_temperature_comfort", "room_temperature_comfort"),
+            ("room_temperature_comfort_plus", "set_room_temperature_comfort_plus", "room_temperature_comfort_plus"),
+            ("room_temperature_comfort_minus", "set_room_temperature_comfort_minus", "room_temperature_comfort_minus"),
+            ("dhw_temperature_economy", "set_water_economy_temperature", "cwu_temperature_economy"),
+            ("dhw_temperature_comfort", "set_water_comfort_temperature", "cwu_temperature_comfort"),
         ]:
             setattr(mock_controller, _setter, AsyncMock(return_value=True))
         mock_coordinator.data = mock_controller
         mock_coordinator.async_request_refresh = AsyncMock()
 
-        entity = KospelRoomPresetNumberEntity(
-            mock_coordinator, mock_entry, translation_key, setter_name
+        entity = KospelPresetNumberEntity(
+            mock_coordinator,
+            mock_entry,
+            translation_key,
+            value_attr,
+            setter_name,
+            ROOM_PRESET_TEMP_MIN if translation_key.startswith("room_") else DHW_PRESET_TEMP_MIN,
+            ROOM_PRESET_TEMP_MAX if translation_key.startswith("room_") else DHW_PRESET_TEMP_MAX,
         )
 
         with patch(


### PR DESCRIPTION
# Add DHW Preset Temperature Support (Economy/Comfort)

## Overview

This PR adds support for
1. controlling DHW (Domestic Hot Water) preset temperatures in economy and comfort modes, Fixes #52 
2. setting external temperature threshold value to stop heating, Fixes #48 

## Changes

### New Entities

#### Sensor
- **`Outside temperature`** - Reads outside temperature sensor value

#### Number

- **`DWH Eco`** – Controls the DHW economy preset temperature (30–80 °C)
- **`DWH Comfort`** – Controls the DHW comfort preset temperature (30–80 °C)
- **`Outside temperature switch off threshold`** - Controls threshold temperature to disable heaiting (0-30 °C)

### Implementation Details

#### Core Changes (`custom_components/kospel/number.py`)

- Refactored the room preset number entity into a generic `KospelPresetNumberEntity` class that supports any temperature preset range
- Added DHW preset entity definitions with
- Room presets remain at 10–25 °C range with 0.1 °C step
- Set number entity mode to BOX (default behavior depends on number of possible values)

#### Localization

Added English and Polish translations

#### Documentation Updates

- **README.md**: Added DHW preset entities to the Number (Configuration) section
- **docs/advanced-usage.md**: Documented DHW preset temperatures alongside room presets

Closes #52
Closes #48 