### PR TITLE
Add outside temperature sensor entity

### DIFF
--- a/custom_components/kospel/sensor.py
+++ b/custom_components/kospel/sensor.py
@@ -34,6 +34,7 @@ async def async_setup_entry(
         ("room_setpoint", "room_setpoint"),
         ("supply_setpoint", "supply_setpoint"),
         ("room_temperature", "room_temperature"),
+        ("outside_temperature", "outside_temperature"),
         ("water_temperature", "water_current_temperature"),
     ]
 

--- a/custom_components/kospel/strings.json
+++ b/custom_components/kospel/strings.json
@@ -97,6 +97,9 @@
       "room_temperature": {
         "name": "CH temperature"
       },
+      "outside_temperature": {
+        "name": "Outside temperature"
+      },
       "water_temperature": {
         "name": "DHW temperature"
       },

--- a/custom_components/kospel/translations/pl.json
+++ b/custom_components/kospel/translations/pl.json
@@ -97,6 +97,9 @@
       "room_temperature": {
         "name": "Temperatura CO"
       },
+      "outside_temperature": {
+        "name": "Temperatura zewnętrzna"
+      },
       "water_temperature": {
         "name": "Temperatura CWU"
       },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,8 @@ def sample_registers() -> Dict[str, str]:
         "0b67": "c201",
         # Register 0b4a - Water current temperature (420 = 42.0°C)
         "0b4a": "a401",
+        # Register 0b4c - Outside temperature (150 = 15.0°C)
+        "0b4c": "9600",
         # Register 0b4b - Room temperature (210 = 21.0°C)
         "0b4b": "d200",
         # Register 0b46 - Power (0 kW)

--- a/tests/integration/test_water_heater_registers.py
+++ b/tests/integration/test_water_heater_registers.py
@@ -19,6 +19,16 @@ class TestWaterHeaterRegisters:
         assert controller.water_current_temperature == 42.0
 
     @pytest.mark.asyncio
+    async def test_outside_temperature_decoded(
+        self, heater_controller_with_registers: EkcoM3
+    ) -> None:
+        """outside_temperature is decoded from register 0b4c."""
+        controller = heater_controller_with_registers
+        assert hasattr(controller, "outside_temperature")
+        # sample_registers has 0b4c: "9600" = 150 = 15.0°C
+        assert controller.outside_temperature == 15.0
+
+    @pytest.mark.asyncio
     async def test_pressure_decoded_from_0b4e(
         self, heater_controller_with_registers: EkcoM3
     ) -> None:


### PR DESCRIPTION
## Summary
Add support for the outdoor temperature sensor by exposing the `EkcoM3.outside_temperature` register value from register `0b4c`.

## What changed
- Added `outside_temperature` to the Kospel temperature sensor platform in `custom_components/kospel/sensor.py`
- Added English translation for `sensor.outside_temperature` in `custom_components/kospel/strings.json`
- Added Polish translation for `sensor.outside_temperature` in `custom_components/kospel/translations/pl.json`
- Added sample register `0b4c` to the integration test fixture in `tests/conftest.py`
- Added an integration test in `tests/integration/test_water_heater_registers.py` verifying outside temperature decoding

## Testing
- `pytest tests/integration/test_water_heater_registers.py` ✅
- `pytest tests/test_sensor_entity.py` ✅

## Issue
Fixes #53: Add Outside Temperature Support
