### PR TITLE
Support dynamic boiler power limit options

### DIFF
--- a/custom_components/kospel/manifest.json
+++ b/custom_components/kospel/manifest.json
@@ -10,7 +10,7 @@
   "issue_tracker": "https://github.com/JanKrl/ha-kospel-cmi/issues",
   "requirements": [
     "aiohttp>=3.13.3",
-    "kospel-cmi-lib>=1.0.2,<2.0.0"
+    "kospel-cmi-lib>=1.1.0,<2.0.0"
   ],
   "version": "0.1.0"
 }

--- a/custom_components/kospel/manifest.json
+++ b/custom_components/kospel/manifest.json
@@ -1,16 +1,21 @@
 {
   "domain": "kospel",
   "name": "Kospel Electric Heaters",
-  "codeowners": ["@JanKrl"],
+  "codeowners": [
+    "@JanKrl"
+  ],
   "config_flow": true,
-  "dependencies": ["http", "network"],
+  "dependencies": [
+    "http",
+    "network"
+  ],
   "documentation": "https://github.com/JanKrl/ha-kospel-cmi",
   "integration_type": "hub",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/JanKrl/ha-kospel-cmi/issues",
   "requirements": [
     "aiohttp>=3.13.3",
-    "kospel-cmi-lib>=1.1.0,<2.0.0"
+    "kospel-cmi-lib>=1.1.0,<1.2.0"
   ],
   "version": "0.1.0"
 }

--- a/custom_components/kospel/manifest.json
+++ b/custom_components/kospel/manifest.json
@@ -15,7 +15,7 @@
   "issue_tracker": "https://github.com/JanKrl/ha-kospel-cmi/issues",
   "requirements": [
     "aiohttp>=3.13.3",
-    "kospel-cmi-lib>=1.0.2,<1.1.0"
+    "kospel-cmi-lib>=1.1.0,<1.2.0"
   ],
   "version": "0.1.0"
 }

--- a/custom_components/kospel/select.py
+++ b/custom_components/kospel/select.py
@@ -13,32 +13,11 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from kospel_cmi import KospelError
 from kospel_cmi.controller.device import EkcoM3
-from kospel_cmi.registers.enums import BoilerMaxPowerIndex
 
 from .const import DOMAIN, get_device_info, get_device_identifier, get_refresh_delay_after_set
 from .coordinator import KospelDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
-
-# Stable order 0..3 for HA options (do not rely on Enum iteration order).
-_BOILER_MAX_POWER_ORDER: tuple[BoilerMaxPowerIndex, ...] = (
-    BoilerMaxPowerIndex.KW_2,
-    BoilerMaxPowerIndex.KW_4,
-    BoilerMaxPowerIndex.KW_6,
-    BoilerMaxPowerIndex.KW_8,
-)
-
-_OPTION_FOR_INDEX: dict[BoilerMaxPowerIndex, str] = {
-    BoilerMaxPowerIndex.KW_2: "2",
-    BoilerMaxPowerIndex.KW_4: "4",
-    BoilerMaxPowerIndex.KW_6: "6",
-    BoilerMaxPowerIndex.KW_8: "8",
-}
-
-_INDEX_FOR_OPTION: dict[str, BoilerMaxPowerIndex] = {
-    v: k for k, v in _OPTION_FOR_INDEX.items()
-}
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -58,7 +37,6 @@ class KospelBoilerMaxPowerSelectEntity(
     _attr_has_entity_name = True
     _attr_translation_key = "boiler_max_power"
     _attr_entity_category = EntityCategory.CONFIG
-    _attr_options = [_OPTION_FOR_INDEX[idx] for idx in _BOILER_MAX_POWER_ORDER]
 
     def __init__(
         self,
@@ -77,13 +55,22 @@ class KospelBoilerMaxPowerSelectEntity(
         self._attr_device_info = get_device_info(entry)
 
     @property
+    def options(self) -> list[str]:
+        """Return a set of selectable options dynamically from the heater."""
+        controller: EkcoM3 = self.coordinator.data
+        return [str(int(kw)) for kw in controller.available_boiler_max_power_settings]
+
+    @property
     def current_option(self) -> str | None:
         """Return the selected kW step as a string (e.g. '4'), or None if unknown."""
         controller: EkcoM3 = self.coordinator.data
         index = controller.boiler_max_power_index
         if index is None:
             return None
-        return _OPTION_FOR_INDEX.get(index)
+        available = controller.available_boiler_max_power_settings
+        if index < len(available):
+            return str(int(available[index]))
+        return None
 
     @property
     def available(self) -> bool:
@@ -92,11 +79,14 @@ class KospelBoilerMaxPowerSelectEntity(
 
     async def async_select_option(self, option: str) -> None:
         """Write the selected power step to the heater and refresh coordinator data."""
-        chosen = _INDEX_FOR_OPTION.get(option)
-        if chosen is None:
+        controller: EkcoM3 = self.coordinator.data
+        available_strs = [str(int(kw)) for kw in controller.available_boiler_max_power_settings]
+        
+        try:
+            chosen = available_strs.index(option)
+        except ValueError:
             raise ValueError(f"Invalid option: {option}")
 
-        controller: EkcoM3 = self.coordinator.data
         try:
             await controller.set_boiler_max_power_index(chosen)
         except KospelError as err:

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -47,8 +47,7 @@ This page is for users who want deeper control, better diagnostics, or developme
 - `number` entity exposes the outside temperature switch-off threshold:
   - When outside temperature exceeds this threshold, the heater turns off.
 - `select` entity exposes boiler max power step:
-  - power steps are device-specific,
-  - `2`, `4`, `6`, `8` kW steps are for **EKCO.M3**.
+  - power steps are dynamically discovered based on the connected device hardware configuration.
 
 ### Heating status sensors (deprecated)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license-files = ["LICENSE*"]
 requires-python = ">=3.11"
 dependencies = [
     "aiohttp>=3.13.3",
-    "kospel-cmi-lib>=1.0.0,<2.0.0",
+    "kospel-cmi-lib>=1.1.0,<2.0.0",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/tests/test_select_entity.py
+++ b/tests/test_select_entity.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from kospel_cmi.registers.enums import BoilerMaxPowerIndex
+
 
 # Mock homeassistant before importing integration modules.
 class _HAModule:
@@ -91,16 +91,20 @@ class TestKospelBoilerMaxPowerSelectEntity:
     """Tests for options, current_option, and async_select_option."""
 
     def test_options_order_and_numeric_strings(self, mock_coordinator, mock_entry) -> None:
-        """Entity exposes four kW options in index order 0..3."""
+        """Entity exposes options derived dynamically from available settings."""
+        mock_controller = MagicMock()
+        mock_controller.available_boiler_max_power_settings = [4.0, 6.0, 8.0]
+        mock_coordinator.data = mock_controller
         entity = KospelBoilerMaxPowerSelectEntity(mock_coordinator, mock_entry)
-        assert entity.options == ["2", "4", "6", "8"]
+        assert entity.options == ["4", "6", "8"]
 
     def test_current_option_maps_enum(
         self, mock_coordinator, mock_entry
     ) -> None:
         """current_option returns kW string for controller.boiler_max_power_index."""
         mock_controller = MagicMock()
-        mock_controller.boiler_max_power_index = BoilerMaxPowerIndex.KW_6
+        mock_controller.boiler_max_power_index = 1
+        mock_controller.available_boiler_max_power_settings = [4.0, 6.0, 8.0]
         mock_coordinator.data = mock_controller
 
         entity = KospelBoilerMaxPowerSelectEntity(mock_coordinator, mock_entry)
@@ -123,6 +127,7 @@ class TestKospelBoilerMaxPowerSelectEntity:
     ) -> None:
         """set_boiler_max_power_index is awaited; coordinator refresh runs."""
         mock_controller = MagicMock()
+        mock_controller.available_boiler_max_power_settings = [4.0, 6.0, 8.0]
         mock_controller.set_boiler_max_power_index = AsyncMock(return_value=True)
         mock_coordinator.data = mock_controller
         mock_coordinator.async_request_refresh = AsyncMock()
@@ -132,11 +137,11 @@ class TestKospelBoilerMaxPowerSelectEntity:
         with patch(
             "custom_components.kospel.select.asyncio.sleep", new_callable=AsyncMock
         ):
-            await entity.async_select_option("4")
+            await entity.async_select_option("6")
 
         mock_controller.set_boiler_max_power_index.assert_awaited_once()
         call_arg = mock_controller.set_boiler_max_power_index.await_args[0][0]
-        assert call_arg == BoilerMaxPowerIndex.KW_4
+        assert call_arg == 1
         mock_coordinator.async_request_refresh.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -145,6 +150,7 @@ class TestKospelBoilerMaxPowerSelectEntity:
     ) -> None:
         """Invalid option string raises ValueError."""
         mock_controller = MagicMock()
+        mock_controller.available_boiler_max_power_settings = [4.0, 6.0, 8.0]
         mock_coordinator.data = mock_controller
 
         entity = KospelBoilerMaxPowerSelectEntity(mock_coordinator, mock_entry)

--- a/uv.lock
+++ b/uv.lock
@@ -397,7 +397,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.3" },
-    { name = "kospel-cmi-lib", specifier = ">=1.0.0,<2.0.0" },
+    { name = "kospel-cmi-lib", specifier = ">=1.1.0,<2.0.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -433,7 +433,7 @@ wheels = [
 
 [[package]]
 name = "kospel-cmi-lib"
-version = "1.0.0"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -441,9 +441,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/81/18a3770bfd254e32b365e284203dc822d47a511c1a202e7649ac0d2284b2/kospel_cmi_lib-1.0.0.tar.gz", hash = "sha256:3fe0e1fdaff2fd667ffffae163dcc03932f19ab27d450762994c8982a5f1dcf1", size = 35310, upload-time = "2026-04-17T15:17:07.827Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/32/14718c94a8018af01238948438917e05bf10c15e46de1bbc64eeaee334f3/kospel_cmi_lib-1.1.0.tar.gz", hash = "sha256:916e1f66da5fed7aa8d2a240d5ff18f45a1add4079b2b0f679622adc04101643", size = 35479, upload-time = "2026-07-15T20:10:55.383Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/43/ed520c0a9d2f4c67431807c2408facce652b12f37adae930b1270685a207/kospel_cmi_lib-1.0.0-py3-none-any.whl", hash = "sha256:197e6ca149835eed28c5a911f6782790b9f707d6c7f6d7561b2f3b01e78fbe2c", size = 47689, upload-time = "2026-04-17T15:17:06.311Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/89/812468e8b95c657d3d3cedd6cbe83cafdf06e1bf3e58ccb55ca76d9ef910/kospel_cmi_lib-1.1.0-py3-none-any.whl", hash = "sha256:5ff1b184b0a8a2c1c5d65b8c995d4e87af95cdcf0fbd03a6c1de40114f46f387", size = 47832, upload-time = "2026-07-15T20:10:53.976Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

This PR updates the integration to read the dynamically queried available boiler power limits from the newly introduced features in `kospel-cmi-lib`, replacing the hardcoded enum `BoilerMaxPowerIndex`.

## Motivation

The library `kospel-cmi-lib` has added support for dynamically reading the available settings for a boiler. Instead of keeping a hardcoded map of kW indexes, this PR exposes the dynamically fetched option strings directly to the Home Assistant select entity. This makes the integration more robust to different firmware versions and devices.

## Changes

- Bumped `kospel-cmi-lib` dependency to `>=1.1.0,<2.0.0`
- Updated `KospelBoilerMaxPowerSelectEntity` to implement dynamic `options` property
- Updated `current_option` and `async_select_option` logic to use dynamically queried data
- Refactored `tests/test_select_entity.py` to remove legacy enum and use dynamic property mocks

## Testing

- [x] All existing tests pass (`uv run python -m pytest tests/ -v`)
- [ ] New tests added (if applicable)
- [x] Manually tested with Home Assistant (if applicable)

## Checklist

- [x] Code follows project conventions (see [CLAUDE.md](CLAUDE.md#key-conventions))
- [ ] Type hints added for new/modified public methods
- [ ] Translation keys added to `strings.json` (if new entities/UI strings)
- [x] Documentation updated (if user-facing behavior changed)

Closes #57 
