### PR TITLE
Update kospel-cmi-lib version range in manifest.json

### DIFF
--- a/custom_components/kospel/manifest.json
+++ b/custom_components/kospel/manifest.json
@@ -10,7 +10,7 @@
   "issue_tracker": "https://github.com/JanKrl/ha-kospel-cmi/issues",
   "requirements": [
     "aiohttp>=3.13.3",
-    "kospel-cmi-lib>=1.0.2,<2.0.0"
+    "kospel-cmi-lib>=1.0.2,<1.1.0"
   ],
   "version": "0.1.0"
 }


### PR DESCRIPTION
## Description

Hotfix for invalid version constraints

## Motivation

On Home Assistant restart the kospel-cmi-lib is updated to latest, backward incompatible version

## Changes

manifest.json

## Testing

<!-- How was this tested? Describe test commands run, manual verification steps, etc. -->

- [x] All existing tests pass (`uv run python -m pytest tests/ -v`)
- [ ] New tests added (if applicable)
- [ ] Manually tested with Home Assistant (if applicable)

## Checklist

- [x] Code follows project conventions (see [CLAUDE.md](CLAUDE.md#key-conventions))
- [ ] Type hints added for new/modified public methods
- [ ] Translation keys added to `strings.json` (if new entities/UI strings)
- [ ] Documentation updated (if user-facing behavior changed)
