### PR TITLE
ci: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    # Ignore major version bumps to prevent breaking changes
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  # Maintain GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Maintain Python dependencies for the integration and library
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Ignore major version bumps to prevent breaking changes
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,14 @@ updates:
     schedule:
       interval: "weekly"
 
-  # Maintain Python dependencies for the integration and library
+  # Maintain Python dependencies for the root Home Assistant integration
   - package-ecosystem: "pip"
     directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Maintain Python dependencies for the kospel-cmi-lib package
+  - package-ecosystem: "pip"
+    directory: "/lib"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Sets up dependabot to check for updates weekly for both GitHub Actions and Python dependencies, while ignoring major semver updates to prevent breaking changes.