### PR TITLE
fix(ha): remove strict aiohttp requirement

### DIFF
--- a/custom_components/kospel/manifest.json
+++ b/custom_components/kospel/manifest.json
@@ -14,7 +14,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/JanKrl/ha-kospel-cmi/issues",
   "requirements": [
-    "aiohttp~=3.13.3",
     "kospel-cmi-lib~=1.1.0"
   ],
   "version": "1.3.0"

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 license-files = ["LICENSE*"]
 requires-python = ">=3.10"
 dependencies = [
-    "aiohttp~=3.13.3",
+    "aiohttp>=3.9.0",
     "aiofiles~=23.1.0",
     "pydantic~=2.11.0",
     "pyyaml~=6.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 license-files = ["LICENSE*"]
 requires-python = ">=3.11"
 dependencies = [
-    "aiohttp>=3.13.3",
+    "aiohttp>=3.9.0",
     "kospel-cmi-lib>=1.1.0,<2.0.0",
 ]
 classifiers = [


### PR DESCRIPTION
Removes aiohttp from manifest.json to prevent conflicts with Home Assistant Core, and reverts pyproject.toml constraints to >=3.9.0.