### PR TITLE
chore(ci): fix release-please tags for HACS compatibility

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -23,7 +23,7 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          include-component-in-tag: true
+          include-component-in-tag: false
 
   publish-lib:
     name: Publish kospel-cmi-lib to PyPI

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,3 @@
 {
-  "name": "Kospel Electric Heaters",
-  "content_in_root": false,
-  "homeassistant": "2024.1.0"
+  "name": "Kospel Electric Heaters"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,3 +1,0 @@
-{
-  "name": "Kospel Electric Heaters"
-}

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,5 @@
 {
   "name": "Kospel Electric Heaters",
   "content_in_root": false,
-  "homeassistant": "2024.1.0",
-  "persistent_directory": "data"
+  "homeassistant": "2024.1.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,7 @@
       "release-type": "python",
       "package-name": "ha-kospel-cmi",
       "changelog-path": "CHANGELOG.md",
-      "draft": true,
+      "draft": false,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "extra-files": [


### PR DESCRIPTION
Sets include-component-in-tag to false so the primary Home Assistant integration receives standard vX.Y.Z tags instead of ha-kospel-cmi-vX.Y.Z, making it natively compatible with HACS.