### PR TITLE
fix: resolve enum error by publishing library and forcing upgrade

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -25,10 +25,31 @@ jobs:
           manifest-file: .release-please-manifest.json
           include-component-in-tag: true
 
+  check-lib-release:
+    name: Check if kospel-cmi-lib was released
+    runs-on: ubuntu-latest
+    outputs:
+      lib_bumped: ${{ steps.check.outputs.lib_bumped }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - id: check
+        run: |
+          if [[ "${{ github.event.head_commit.message }}" == *"chore: release"* ]] || [[ "${{ github.event.head_commit.message }}" == *"chore(master): release"* ]]; then
+            if git diff --name-only HEAD^ HEAD | grep -q "^lib/pyproject\.toml$"; then
+              echo "lib_bumped=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "lib_bumped=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "lib_bumped=false" >> "$GITHUB_OUTPUT"
+          fi
+
   publish-lib:
     name: Publish kospel-cmi-lib to PyPI
-    needs: release-please
-    if: ${{ needs.release-please.outputs.lib--release_created == 'true' }}
+    needs: [release-please, check-lib-release]
+    if: ${{ needs.check-lib-release.outputs.lib_bumped == 'true' }}
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -23,7 +23,6 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          include-component-in-tag: true
 
   check-lib-release:
     name: Check if kospel-cmi-lib was released

--- a/custom_components/kospel/manifest.json
+++ b/custom_components/kospel/manifest.json
@@ -14,7 +14,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/JanKrl/ha-kospel-cmi/issues",
   "requirements": [
-    "kospel-cmi-lib~=1.1.0"
+    "kospel-cmi-lib==1.1.4"
   ],
   "version": "1.3.1"
 }

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,5 +1,6 @@
 # kospel-cmi-lib
 
+
 Python client for the Kospel C.MI electric heater HTTP API.
 
 This library provides a Python client for controlling Kospel C.MI electric heaters via their HTTP API. It is designed for integration with Home Assistant and other automation systems, and supports device discovery, register-based control, and offline development with a YAML simulator.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,8 +23,7 @@
       "package-name": "kospel-cmi-lib",
       "component": "lib",
       "changelog-path": "lib/CHANGELOG.md",
-      "bump-minor-pre-major": true,
-      "skip-github-release": true
+      "bump-minor-pre-major": true
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,7 +23,8 @@
       "package-name": "kospel-cmi-lib",
       "component": "lib",
       "changelog-path": "lib/CHANGELOG.md",
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "skip-github-release": true
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,6 +10,7 @@
       "draft": true,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
+      "include-component-in-tag": false,
       "extra-files": [
         {
           "type": "json",
@@ -24,6 +25,7 @@
       "component": "lib",
       "changelog-path": "lib/CHANGELOG.md",
       "bump-minor-pre-major": true,
+      "include-component-in-tag": true,
       "skip-github-release": true
     }
   }


### PR DESCRIPTION
Fixes #86. Removes skip-github-release so the library actually publishes to PyPI, and forces the Home Assistant integration to upgrade to the new version.