### PR TITLE
fix: relax library dependency versions for HA compatibility

### DIFF
--- a/custom_components/kospel/manifest.json
+++ b/custom_components/kospel/manifest.json
@@ -14,7 +14,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/JanKrl/ha-kospel-cmi/issues",
   "requirements": [
-    "kospel-cmi-lib==1.1.4"
+    "kospel-cmi-lib==1.1.5"
   ],
   "version": "1.3.2"
 }

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -12,9 +12,9 @@ license-files = ["LICENSE*"]
 requires-python = ">=3.10"
 dependencies = [
     "aiohttp>=3.9.0",
-    "aiofiles~=23.1.0",
-    "pydantic~=2.11.0",
-    "pyyaml~=6.0.0",
+    "aiofiles>=23.1.0",
+    "pydantic>=2.11.0",
+    "pyyaml>=6.0.0",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Home Assistant strictly manages its own package versions. The previous strict constraint `~=` (e.g. `pydantic~=2.11.0`) prevented the library from being installed when HA used a newer minor version (like 2.13.4). This PR relaxes the constraints to `>=` so Home Assistant can successfully install the library without conflicts. Also bumps manifest requirement to the upcoming library version.