### PR TITLE
fix(ci): add checkout step to cleanup workflow

### DIFF
--- a/.github/workflows/cleanup-prereleases.yml
+++ b/.github/workflows/cleanup-prereleases.yml
@@ -13,6 +13,9 @@ jobs:
       contents: write # Required to delete releases and tags
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Delete old pre-releases
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The GitHub action runner requires the repository to be checked out for the `gh release delete --cleanup-tag` command to be able to delete tags locally and push those deletions. This PR adds the missing `actions/checkout@v4` step.

BEGIN_COMMIT_OVERRIDE
ci: add checkout step to cleanup workflow
END_COMMIT_OVERRIDE