### PR TITLE
docs: add commit warning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,9 @@ release-please reads file paths (not scopes) to assign commits to packages, but 
 
 > **Exception:** `release-please` PRs MUST be **merge committed** (Create a merge commit). Do not squash-merge release PRs, as this breaks the automated release tracking.
 
+> [!WARNING]
+> **Avoid `fix(ci)` or `feat(ci)`:** Because `release-please` triggers on the `fix` and `feat` types, using them for CI changes will accidentally include internal workflows in the user-facing changelog. ALWAYS use the `ci:` or `chore:` type (e.g., `ci: update checkout step`) for pipeline updates so they are correctly ignored.
+
 **Breaking changes**: add `BREAKING CHANGE: <description>` as a footer in the PR description body.
 
 ### Pull Request & Issue Workflow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,10 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/) t
 > The old .start()/.stop() API is removed.
 > ```
 
+> [!WARNING]
+> **Avoid `fix(ci)` or `feat(ci)`:** Because `release-please` triggers on the `fix` and `feat` types, using them for CI changes will accidentally include internal workflows in the user-facing changelog. ALWAYS use the `ci:` or `chore:` type (e.g., `ci: update checkout step`) for pipeline updates so they are correctly ignored.
+
+
 ### Scopes (Recommended)
 
 Using a scope in the PR title makes it immediately clear which package is affected:


### PR DESCRIPTION
Added warnings to CONTRIBUTING.md and CLAUDE.md to prevent AI agents and developers from accidentally populating the changelog with internal CI changes.