### PR TITLE
fix: correct valve position mapping

### DIFF
--- a/lib/src/kospel_cmi/controller/device.py
+++ b/lib/src/kospel_cmi/controller/device.py
@@ -49,7 +49,7 @@ _decode_co_heating_active = decode_map(
 _decode_cwu_heating_active = decode_map(
     HeatingCircuitActive.ACTIVE, HeatingCircuitActive.INACTIVE
 )
-_decode_valve_position = decode_map(ValvePosition.CH, ValvePosition.DHW)
+_decode_valve_position = decode_map(ValvePosition.DHW, ValvePosition.CH)
 
 _encode_water_heater_enabled = encode_map(
     WaterHeaterEnabled.ENABLED, WaterHeaterEnabled.DISABLED

--- a/uv.lock
+++ b/uv.lock
@@ -392,7 +392,7 @@ wheels = [
 
 [[package]]
 name = "ha-kospel-cmi"
-version = "1.1.1"
+version = "1.3.3"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -414,7 +414,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiohttp", specifier = ">=3.13.3" },
+    { name = "aiohttp", specifier = ">=3.9.0" },
     { name = "kospel-cmi-lib", editable = "lib" },
 ]
 
@@ -451,7 +451,7 @@ wheels = [
 
 [[package]]
 name = "kospel-cmi-lib"
-version = "1.1.0"
+version = "1.1.5"
 source = { editable = "lib" }
 dependencies = [
     { name = "aiofiles" },
@@ -471,18 +471,18 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiofiles", specifier = "~=23.1.0" },
-    { name = "aiohttp", specifier = "~=3.13.3" },
-    { name = "pydantic", specifier = "~=2.11.0" },
-    { name = "pyyaml", specifier = "~=6.0.0" },
+    { name = "aiofiles", specifier = ">=23.1.0" },
+    { name = "aiohttp", specifier = ">=3.9.0" },
+    { name = "pydantic", specifier = ">=2.11.0" },
+    { name = "pyyaml", specifier = ">=6.0.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "aioresponses", specifier = "~=0.7.8" },
-    { name = "coverage", extras = ["toml"], specifier = "~=7.13.2" },
-    { name = "pytest", specifier = "~=9.0.2" },
-    { name = "pytest-asyncio", specifier = "~=1.3.0" },
+    { name = "coverage", extras = ["toml"], specifier = ">=7.13.2,<7.16.0" },
+    { name = "pytest", specifier = ">=9.0.2,<9.2.0" },
+    { name = "pytest-asyncio", specifier = ">=1.3,<1.5" },
     { name = "pyyaml", specifier = "~=6.0.3" },
 ]
 


### PR DESCRIPTION
Ref #95. Swaps the `ValvePosition.CH` and `ValvePosition.DHW` mappings in the valve position decoder to correctly reflect the physical behavior where bit 1 corresponds to DHW and 0 corresponds to CH.