### PR TITLE
chore: enable python-workspace plugin in release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "python",
   "bootstrap-sha": "24c1432e82a6efb5dd47007ebc929c83636ef4bc",
+  "plugins": [
+    "python-workspace"
+  ],
   "packages": {
     ".": {
       "release-type": "python",


### PR DESCRIPTION
Enables the `python-workspace` plugin in `release-please-config.json`. Now, when `kospel-cmi-lib` is released, `release-please` will automatically bump its dependency version in `pyproject.toml` and open a Release PR for `ha-kospel-cmi`.