### PR TITLE
chore: bump kospel-cmi-lib to 1.1.6

### DIFF
--- a/custom_components/kospel/manifest.json
+++ b/custom_components/kospel/manifest.json
@@ -14,7 +14,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/JanKrl/ha-kospel-cmi/issues",
   "requirements": [
-    "kospel-cmi-lib==1.1.5"
+    "kospel-cmi-lib==1.1.6"
   ],
   "version": "1.3.3"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license-files = ["LICENSE*"]
 requires-python = ">=3.11"
 dependencies = [
     "aiohttp>=3.9.0",
-    "kospel-cmi-lib>=1.1.0,<2.0.0",
+    "kospel-cmi-lib>=1.1.6,<2.0.0",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Bumps `kospel-cmi-lib` requirement in `manifest.json` and `pyproject.toml` to `1.1.6` so the integration uses the newly released fix. This will trigger `release-please` to update the integration release PR.