### PR TITLE
ci: improve release automation and safeguard PR merges

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,3 +84,19 @@ jobs:
         run: uv run python -m pytest tests/ -v
         working-directory: lib
 
+  validate-manifest-requirements:
+    name: Validate Manifest Requirements
+    runs-on: ubuntu-latest
+    if: startsWith(github.head_ref, 'release-please--branches--')
+    steps:
+      - uses: actions/checkout@v7
+      - name: Check version match
+        run: |
+          LIB_VERSION=$(grep -oP '(?<=^version = ")[^"]+' lib/pyproject.toml)
+          MANIFEST_REQ=$(grep -oP '"kospel-cmi-lib==\K[^"]+' custom_components/kospel/manifest.json)
+          if [ "$LIB_VERSION" != "$MANIFEST_REQ" ]; then
+            echo "::error::manifest.json requires kospel-cmi-lib==$MANIFEST_REQ, but lib/pyproject.toml is at $LIB_VERSION."
+            echo "Please update custom_components/kospel/manifest.json to require kospel-cmi-lib==$LIB_VERSION."
+            exit 1
+          fi
+          echo "Versions match: $LIB_VERSION"

--- a/.github/workflows/command-merge.yaml
+++ b/.github/workflows/command-merge.yaml
@@ -1,0 +1,53 @@
+name: Command Merge
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  merge:
+    name: Auto-merge PR
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/merge')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Verify and Merge
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=${{ github.event.issue.number }}
+          
+          # 1. Verify PR branch
+          PR_BRANCH=$(gh pr view $PR_NUMBER --json headRefName --jq .headRefName)
+          if [[ ! "$PR_BRANCH" == release-please--branches--* ]]; then
+            echo "::error::The /merge command can only be used on release-please PRs."
+            gh pr comment $PR_NUMBER --body "❌ The \`/merge\` command can only be used on release-please PRs."
+            exit 1
+          fi
+
+          # 2. Add reaction to acknowledge command
+          gh api -X POST repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions -f content=eyes > /dev/null
+
+          # Give GitHub Actions a few seconds to register newly triggered checks
+          sleep 10
+
+          # 3. Wait for CI checks
+          echo "Waiting for CI to complete..."
+          if ! gh pr checks $PR_NUMBER --watch; then
+             echo "::error::CI checks failed."
+             gh pr comment $PR_NUMBER --body "❌ Cannot merge. CI checks failed or are pending."
+             exit 1
+          fi
+
+          # 4. Merge
+          echo "Merging PR..."
+          if gh pr merge $PR_NUMBER --merge; then
+             gh pr comment $PR_NUMBER --body "✅ Successfully merged release PR using a merge commit."
+          else
+             echo "::error::Failed to merge PR."
+             gh pr comment $PR_NUMBER --body "❌ Failed to merge PR."
+             exit 1
+          fi

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -53,6 +53,7 @@ jobs:
     environment: pypi
     permissions:
       id-token: write  # Required for OIDC Trusted Publisher authentication
+      contents: write  # Required to push the git tag
     steps:
       - uses: actions/checkout@v7
 
@@ -74,3 +75,11 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
+
+      - name: Create and push Git tag
+        run: |
+          VERSION=$(grep -oP '(?<=^version = ")[^"]+' lib/pyproject.toml)
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "lib-v$VERSION"
+          git push origin "lib-v$VERSION"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -25,7 +25,8 @@
       "component": "lib",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
-      "include-component-in-tag": true
+      "include-component-in-tag": true,
+      "skip-github-release": true
     }
   }
 }

--- a/uv.lock
+++ b/uv.lock
@@ -392,7 +392,7 @@ wheels = [
 
 [[package]]
 name = "ha-kospel-cmi"
-version = "1.3.3"
+version = "1.3.4"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -451,7 +451,7 @@ wheels = [
 
 [[package]]
 name = "kospel-cmi-lib"
-version = "1.1.5"
+version = "1.1.6"
 source = { editable = "lib" }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
This PR introduces several improvements to the release pipeline:

- **Library Tagging**: Bypasses GitHub releases for the library via `skip-github-release`, opting for manual git tags created via CI after successful PyPI publication to prevent noisy Releases pages.
- **Manifest Validation**: Adds a CI check on release-please PRs to ensure `manifest.json` versions correctly track library bumps.
- **Slash Command**: Introduces a `/merge` Slash Command workflow to automatically and safely merge release PRs using a merge commit, preventing accidental squashes.