### PR TITLE
refactor: rename cwu/co identifiers to dhw/ch across codebase for consistency

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,6 +1,6 @@
-# CLAUDE.md — AI Agent Context for ha-kospel-cmi
+# AGENTS.md — AI Agent Context for ha-kospel-cmi
 
-This file provides structured context for Claude, Antigravity, and similar AI coding agents working on this repository.
+This file provides structured context for Antigravity and similar AI coding agents working on this repository.
 
 For human-readable documentation, start with [README.md](README.md).
 
@@ -289,6 +289,7 @@ For the full release workflow and commit conventions, see [CONTRIBUTING.md](CONT
 6. **Don't use `CO`/`CWU` in new code identifiers** — use `CH`/`DHW` in English. The library API now uses English names (`ch_heating_status`, `dhw_heating_status`, `is_ch_heating_active`, `is_dhw_heating_active`).
 7. **Power values**: The library reports kW but HA expects W. Always multiply by 1000 when creating power sensors.
 8. **Config flow VERSION is 2** — any structural changes to config entry data require a new migration step.
+9. **Entity unique_ids**: Changing a setting name in the controller or integration is a breaking change for existing Home Assistant installations because entities will get recreated with new `unique_id`s. When refactoring or renaming settings, you MUST use or add an optional `unique_id_suffix` override (or similar mechanism) in the entity setup to ensure that the entity's `unique_id` remains the same as it was historically. This preserves the existing HA entity registry entries.
 
 ## AI Agent Behavioral Guidelines
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,7 +22,7 @@
 
 ## Checklist
 
-- [ ] Code follows project conventions (see [CLAUDE.md](CLAUDE.md#key-conventions))
+- [ ] Code follows project conventions (see [.agents/AGENTS.md](.agents/AGENTS.md#key-conventions))
 - [ ] Type hints added for new/modified public methods
 - [ ] Translation keys added to `strings.json` (if new entities/UI strings)
 - [ ] Documentation updated (if user-facing behavior changed)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,7 +158,7 @@ from .coordinator import KospelDataUpdateCoordinator
   - Use `CH` (central heating) not `CO` in code
   - Use `DHW` (domestic hot water) not `CWU` in code
 - **Library compatibility fields**: Keep library naming where required
-  - `co_heating_status`, `cwu_heating_status`, `cwu_mode` — these are `kospel-cmi-lib` property names
+  - `ch_heating_status`, `dhw_heating_status`, `cwu_mode` — these are `kospel-cmi-lib` property names
   - Map them to English translation keys in integration code
 - **User-facing labels**: Localized in `strings.json` (English) and `translations/pl.json` (Polish)
 
@@ -286,7 +286,7 @@ For the full release workflow and commit conventions, see [CONTRIBUTING.md](CONT
 3. **Don't forget the refresh delay** after write operations — the heater needs time to persist register changes.
 4. **Don't remove DHCP discovery code** — it's intentionally kept for future use even though it's hidden from the UI.
 5. **Don't use `_attr_name` for entity naming** — use `_attr_translation_key` and `strings.json` for all user-facing names.
-6. **Don't use `CO`/`CWU` in new code identifiers** — use `CH`/`DHW` in English. Library property names like `co_heating_status` are exceptions (they match the library API).
+6. **Don't use `CO`/`CWU` in new code identifiers** — use `CH`/`DHW` in English. The library API now uses English names (`ch_heating_status`, `dhw_heating_status`, `is_ch_heating_active`, `is_dhw_heating_active`).
 7. **Power values**: The library reports kW but HA expects W. Always multiply by 1000 when creating power sensors.
 8. **Config flow VERSION is 2** — any structural changes to config entry data require a new migration step.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,7 +223,7 @@ After merging the HA Release PR:
 ## Adding a New HA Entity
 
 1. Create a new entity module in `custom_components/kospel/` (e.g., `switch.py`).
-2. Follow the entity pattern documented in [CLAUDE.md](CLAUDE.md#entity-patterns).
+2. Follow the entity pattern documented in [AGENTS.md](.agents/AGENTS.md#entity-patterns).
 3. Register the platform in `PLATFORMS` list in `__init__.py`.
 4. Add translation keys in `strings.json` and `translations/pl.json`.
 5. Write tests covering the entity's read properties and write operations.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ See [Advanced usage and technical notes](docs/advanced-usage.md) for:
 - architecture references.
 
 For contributors, see [CONTRIBUTING.md](CONTRIBUTING.md).
-For AI coding agents (Claude, Antigravity, etc.), see [CLAUDE.md](CLAUDE.md).
+For AI coding agents (Claude, Antigravity, etc.), see [AGENTS.md](.agents/AGENTS.md).
 
 ## Feedback and Issues
 

--- a/custom_components/kospel/climate.py
+++ b/custom_components/kospel/climate.py
@@ -130,7 +130,7 @@ class KospelClimateEntity(
     def hvac_action(self) -> HVACAction:
         """HVAC action is based on whether CH heating circuit is active."""
         controller: EkcoM3 = self.coordinator.data
-        ch_status = controller.co_heating_status
+        ch_status = controller.ch_heating_status
         return (
             HVACAction.HEATING
             if ch_status == HeatingStatus.RUNNING

--- a/custom_components/kospel/number.py
+++ b/custom_components/kospel/number.py
@@ -60,14 +60,14 @@ _PRESET_ENTITIES: list[tuple[str, str, str, float, float]] = [
     ),
     (
         "dhw_temperature_economy",
-        "cwu_temperature_economy",
+        "dhw_temperature_economy",
         "set_water_economy_temperature",
         DHW_PRESET_TEMP_MIN,
         DHW_PRESET_TEMP_MAX,
     ),
     (
         "dhw_temperature_comfort",
-        "cwu_temperature_comfort",
+        "dhw_temperature_comfort",
         "set_water_comfort_temperature",
         DHW_PRESET_TEMP_MIN,
         DHW_PRESET_TEMP_MAX,

--- a/custom_components/kospel/number.py
+++ b/custom_components/kospel/number.py
@@ -28,7 +28,7 @@ OUTSIDE_THRESHOLD_MIN = 0
 OUTSIDE_THRESHOLD_MAX = 30
 PRESET_TEMP_STEP = 0.1
 
-# (translation_key / controller property name / async setter name / min temp / max temp)
+# (unique_id_suffix / controller property name & translation key / async setter name / min temp / max temp)
 _PRESET_ENTITIES: list[tuple[str, str, str, float, float]] = [
     (
         "room_temperature_economy",
@@ -59,14 +59,16 @@ _PRESET_ENTITIES: list[tuple[str, str, str, float, float]] = [
         ROOM_PRESET_TEMP_MAX,
     ),
     (
-        "dhw_temperature_economy",
+        # Keep old cwu_ unique_id to preserve existing HA entity registry entries
+        "cwu_temperature_economy",
         "dhw_temperature_economy",
         "set_water_economy_temperature",
         DHW_PRESET_TEMP_MIN,
         DHW_PRESET_TEMP_MAX,
     ),
     (
-        "dhw_temperature_comfort",
+        # Keep old cwu_ unique_id to preserve existing HA entity registry entries
+        "cwu_temperature_comfort",
         "dhw_temperature_comfort",
         "set_water_comfort_temperature",
         DHW_PRESET_TEMP_MIN,
@@ -93,13 +95,13 @@ async def async_setup_entry(
         KospelPresetNumberEntity(
             coordinator,
             entry,
-            translation_key,
+            unique_id_suffix,
             value_attr,
             setter_name,
             min_temp,
             max_temp,
         )
-        for translation_key, value_attr, setter_name, min_temp, max_temp in _PRESET_ENTITIES
+        for unique_id_suffix, value_attr, setter_name, min_temp, max_temp in _PRESET_ENTITIES
     ]
     async_add_entities(entities)
 
@@ -124,7 +126,7 @@ class KospelPresetNumberEntity(
         self,
         coordinator: KospelDataUpdateCoordinator,
         entry: ConfigEntry,
-        translation_key: str,
+        unique_id_suffix: str,
         value_attr: str,
         setter_name: str,
         min_temp: float,
@@ -136,8 +138,8 @@ class KospelPresetNumberEntity(
         Args:
             coordinator: Data update coordinator.
             entry: Config entry (device info and refresh delay options).
-            translation_key: Translation key used for human-friendly entity naming.
-            value_attr: EkcoM3 property name to read from the controller.
+            unique_id_suffix: Unique suffix for entity ID to maintain backward compatibility.
+            value_attr: EkcoM3 property name to read from the controller (also used as translation key).
             setter_name: Name of the async setter on EkcoM3.
             min_temp: Minimum supported temperature for this preset.
             max_temp: Maximum supported temperature for this preset.
@@ -145,8 +147,8 @@ class KospelPresetNumberEntity(
         """
         super().__init__(coordinator)
         device_id = get_device_identifier(entry)
-        self._attr_unique_id = f"{device_id}_{value_attr}"
-        self._attr_translation_key = translation_key
+        self._attr_unique_id = f"{device_id}_{unique_id_suffix}"
+        self._attr_translation_key = value_attr
         self._attr_device_info = get_device_info(entry)
         self._attr_native_min_value = min_temp
         self._attr_native_max_value = max_temp

--- a/custom_components/kospel/sensor.py
+++ b/custom_components/kospel/sensor.py
@@ -61,12 +61,10 @@ async def async_setup_entry(
 
     # Heating status sensors: (unique_id_suffix, setting_name)
     entities.append(
-        KospelHeatingStatusSensor(coordinator, entry, "ch_heating", "co_heating_status")
+        KospelHeatingStatusSensor(coordinator, entry, "ch_heating", "ch_heating_status")
     )
     entities.append(
-        KospelHeatingStatusSensor(
-            coordinator, entry, "dhw_heating", "cwu_heating_status"
-        )
+        KospelHeatingStatusSensor(coordinator, entry, "dhw_heating", "dhw_heating_status")
     )
     entities.append(KospelValvePositionSensor(coordinator, entry))
     
@@ -328,8 +326,8 @@ class KospelHeatingModeSensor(KospelSensorEntity):
         """
         controller: EkcoM3 = self.coordinator.data
         
-        ch_status = getattr(controller, "co_heating_status", None)
-        dwh_status = getattr(controller, "cwu_heating_status", None)
+        ch_status = getattr(controller, "ch_heating_status", None)
+        dwh_status = getattr(controller, "dhw_heating_status", None)
         
         if ch_status is None or dwh_status is None:
             return None

--- a/custom_components/kospel/water_heater.py
+++ b/custom_components/kospel/water_heater.py
@@ -1,4 +1,4 @@
-"""Water heater entity for Kospel integration (CWU / DHW)."""
+"""Water heater entity for Kospel integration (DHW)."""
 
 import logging
 from typing import TypedDict, Unpack
@@ -13,7 +13,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN, get_device_info, get_device_identifier
 from .coordinator import KospelDataUpdateCoordinator
 
-from kospel_cmi.registers.enums import CwuMode, WaterHeaterEnabled
+from kospel_cmi.registers.enums import DhwMode, WaterHeaterEnabled
 from kospel_cmi.controller.device import EkcoM3
 
 _LOGGER = logging.getLogger(__name__)
@@ -25,11 +25,11 @@ STATE_OFF = "off"
 
 OPERATION_LIST = [STATE_ECO, STATE_PERFORMANCE, STATE_OFF]
 
-# CwuMode (0=economy, 1=anti-freeze, 2=comfort) to HA operation mode
-_CWU_MODE_TO_HA: dict[int, str] = {
-    CwuMode.ECONOMY: STATE_ECO,
-    CwuMode.ANTI_FREEZE: STATE_OFF,
-    CwuMode.COMFORT: STATE_PERFORMANCE,
+# DhwMode (0=economy, 1=anti-freeze, 2=comfort) to HA operation mode
+_DHW_MODE_TO_HA: dict[int, str] = {
+    DhwMode.ECONOMY: STATE_ECO,
+    DhwMode.ANTI_FREEZE: STATE_OFF,
+    DhwMode.COMFORT: STATE_PERFORMANCE,
 }
 
 
@@ -53,11 +53,11 @@ async def async_setup_entry(
 class KospelWaterHeaterEntity(
     CoordinatorEntity[KospelDataUpdateCoordinator], WaterHeaterEntity
 ):
-    """Representation of a Kospel domestic hot water (CWU/DHW) entity.
+    """Representation of a Kospel domestic hot water (DHW) entity.
 
     Read-only for writes: displays current temperature, target temperature, and
     operation mode. Target/operation controls on this entity are intentionally
-    no-ops; DHW/CWU setpoints and modes follow the device and the climate entity
+    no-ops; DHW setpoints and modes follow the device and the climate entity
     (HVAC / auto programs), not the water heater card.
     """
 
@@ -70,7 +70,7 @@ class KospelWaterHeaterEntity(
     _attr_max_temp = 65.0
     # OPERATION_MODE and TARGET_TEMPERATURE are declared so Home Assistant shows
     # current operation and temperatures in the UI. Writes are ignored here by design:
-    # DHW/CWU behaviour is driven by the device and by the climate entity (HVAC mode
+    # DHW behaviour is driven by the device and by the climate entity (HVAC mode
     # and auto presets; see climate.async_set_*).
     _attr_supported_features = (
         WaterHeaterEntityFeature.OPERATION_MODE | WaterHeaterEntityFeature.TARGET_TEMPERATURE
@@ -94,7 +94,7 @@ class KospelWaterHeaterEntity(
         _LOGGER.debug("Ignoring set_temperature on read-only DHW entity")
 
     async def async_set_operation_mode(self, operation_mode: str) -> None:
-        """Ignore operation mode writes; CWU mode is not controlled here."""
+        """Ignore operation mode writes; DHW mode is not controlled here."""
         _LOGGER.debug(
             "Ignoring set_operation_mode on read-only DHW entity (mode=%s)",
             operation_mode,
@@ -108,7 +108,7 @@ class KospelWaterHeaterEntity(
 
     @property
     def target_temperature(self) -> float | None:
-        """Return the live CWU supply setpoint from the device (register 0b2f).
+        """Return the live DHW supply setpoint from the device (register 0b2f).
 
         Reflects firmware output including daily programs; not derived from
         static economy/comfort preset registers. ``None`` if the value is
@@ -119,12 +119,12 @@ class KospelWaterHeaterEntity(
 
     @property
     def current_operation(self) -> str:
-        """Return the current operation mode from device cwu_mode."""
+        """Return the current operation mode from device dhw_mode."""
         controller = self._get_controller()
         if controller.is_water_heater_enabled != WaterHeaterEnabled.ENABLED:
             return STATE_OFF
-        cwu_mode = controller.cwu_mode
-        return _CWU_MODE_TO_HA.get(cwu_mode or 0, STATE_ECO)
+        dhw_mode = controller.dhw_mode
+        return _DHW_MODE_TO_HA.get(dhw_mode or 0, STATE_ECO)
 
     @property
     def available(self) -> bool:

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -108,4 +108,4 @@ uv run python -m pytest tests/ -v
 
 - **Architecture**: [docs/architecture.md](architecture.md)
 - **Advanced usage**: [docs/advanced-usage.md](advanced-usage.md)
-- **AI agent context**: [CLAUDE.md](../CLAUDE.md)
+- **AI agent context**: [AGENTS.md](../.agents/AGENTS.md)

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -17,7 +17,7 @@ This project provides a Home Assistant integration for Kospel electric heaters. 
 ### Naming Convention
 
 - Internal code identifiers (entity translation keys, variable names, comments, tests) use English terminology.
-- Device-library compatibility fields keep library naming where required (for example `co_heating_status`, `cwu_heating_status`) and are mapped to English integration keys.
+- Device-library compatibility fields keep library naming where required (for example `ch_heating_status`, `dhw_heating_status`) and are mapped to English integration keys.
 - User-facing labels are localized in translation files:
   - `strings.json`: English labels (`CH`, `DHW`)
   - `translations/pl.json`: Polish labels (`CO`, `CWU`)

--- a/lib/README.md
+++ b/lib/README.md
@@ -160,7 +160,7 @@ Module-specific documentation is co-located with the code (GitHub automatically 
 - **[Development Guide](docs/development.md)** - Contributing and extending the library
 - **[Architecture](docs/architecture.md)** - System design, layers, components, and data flow
 - **[Technical Specs](docs/technical.md)** - Implementation details, data formats, protocols, testing, and coding standards
-- **[AI Context (CLAUDE.md)](CLAUDE.md)** - Entry point and cheat-sheet for AI coding assistants (Copilot, Claude, Antigravity)
+- **[AI Context (AGENTS.md)](../.agents/AGENTS.md)** - Entry point and cheat-sheet for AI coding assistants (Copilot, Claude, Antigravity)
 
 
 ## Known Limitations

--- a/lib/src/kospel_cmi/controller/README.md
+++ b/lib/src/kospel_cmi/controller/README.md
@@ -34,8 +34,8 @@ await controller.set_water_comfort_temperature(38.0)
 
 - `heater_mode`, `manual_temperature`, `room_temperature`, `room_setpoint`
 - `cwu_mode`, `cwu_temperature_economy`, `cwu_temperature_comfort`
-- `is_water_heater_enabled`, `is_co_heating_active`, `is_cwu_heating_active`
-- `co_heating_status`, `cwu_heating_status` (computed)
+- `is_water_heater_enabled`, `is_ch_heating_active`, `is_dhw_heating_active`
+- `ch_heating_status`, `dhw_heating_status` (computed)
 - `pressure`, `power` (0b46, delivered kW), `flow`, `valve_position`, etc.
 - `boiler_max_power_index` (0b62), `boiler_max_power_kw` (0b34, limit in kW; not written by this library—refresh after changing index)
 

--- a/lib/src/kospel_cmi/controller/device.py
+++ b/lib/src/kospel_cmi/controller/device.py
@@ -28,7 +28,7 @@ from ..registers.encoders import (
 )
 from ..registers.enums import (
     ROOM_MODE_MANUAL,
-    CwuMode,
+    DhwMode,
     HeaterMode,
     HeatingCircuitActive,
     HeatingStatus,
@@ -43,10 +43,10 @@ logger = logging.getLogger(__name__)
 _decode_water_heater_enabled = decode_map(
     WaterHeaterEnabled.ENABLED, WaterHeaterEnabled.DISABLED
 )
-_decode_co_heating_active = decode_map(
+_decode_ch_heating_active = decode_map(
     HeatingCircuitActive.ACTIVE, HeatingCircuitActive.INACTIVE
 )
-_decode_cwu_heating_active = decode_map(
+_decode_dhw_heating_active = decode_map(
     HeatingCircuitActive.ACTIVE, HeatingCircuitActive.INACTIVE
 )
 _decode_valve_position = decode_map(ValvePosition.DHW, ValvePosition.CH)
@@ -188,8 +188,8 @@ class EkcoM3:
         return decode_raw_int(self._get_register("0b32"))
 
     @property
-    def cwu_mode(self) -> Optional[int]:
-        """CWU mode: 0=economy, 1=anti-freeze, 2=comfort."""
+    def dhw_mode(self) -> Optional[int]:
+        """DHW mode: 0=economy, 1=anti-freeze, 2=comfort."""
         return decode_raw_int(self._get_register("0b30"))
 
     @property
@@ -198,14 +198,14 @@ class EkcoM3:
         return _decode_water_heater_enabled(self._get_register("0b55"), 4)
 
     @property
-    def is_co_heating_active(self) -> Optional[HeatingCircuitActive]:
-        """CO heating circuit active (bit 7 of 0b51)."""
-        return _decode_co_heating_active(self._get_register("0b51"), 7)
+    def is_ch_heating_active(self) -> Optional[HeatingCircuitActive]:
+        """CH heating circuit active (bit 7 of 0b51)."""
+        return _decode_ch_heating_active(self._get_register("0b51"), 7)
 
     @property
-    def is_cwu_heating_active(self) -> Optional[HeatingCircuitActive]:
-        """CWU heating circuit active (bit 8 of 0b51)."""
-        return _decode_cwu_heating_active(self._get_register("0b51"), 8)
+    def is_dhw_heating_active(self) -> Optional[HeatingCircuitActive]:
+        """DHW heating circuit active (bit 8 of 0b51)."""
+        return _decode_dhw_heating_active(self._get_register("0b51"), 8)
 
     @property
     def valve_position(self) -> Optional[ValvePosition]:
@@ -238,13 +238,13 @@ class EkcoM3:
         return decode_scaled_x10(self._get_register("0b69"))
 
     @property
-    def cwu_temperature_economy(self) -> Optional[float]:
-        """CWU economy temperature (0b66), °C."""
+    def dhw_temperature_economy(self) -> Optional[float]:
+        """DHW economy temperature (0b66), °C."""
         return decode_scaled_x10(self._get_register("0b66"))
 
     @property
-    def cwu_temperature_comfort(self) -> Optional[float]:
-        """CWU comfort temperature (0b67), °C."""
+    def dhw_temperature_comfort(self) -> Optional[float]:
+        """DHW comfort temperature (0b67), °C."""
         return decode_scaled_x10(self._get_register("0b67"))
 
     @property
@@ -373,16 +373,16 @@ class EkcoM3:
     # --- Computed properties ---
 
     @property
-    def co_heating_status(self) -> HeatingStatus:
-        """CO heating status from heater_mode, is_co_heating_active, power."""
+    def ch_heating_status(self) -> HeatingStatus:
+        """CH heating status from heater_mode, is_ch_heating_active, power."""
         heater_mode = self.heater_mode
-        co_active = self.is_co_heating_active
+        ch_active = self.is_ch_heating_active
         power_val = self.power
 
         if heater_mode != HeaterMode.WINTER:
             return HeatingStatus.DISABLED
 
-        if co_active != HeatingCircuitActive.ACTIVE:
+        if ch_active != HeatingCircuitActive.ACTIVE:
             return HeatingStatus.IDLE
 
         if power_val is not None and power_val > 0:
@@ -390,17 +390,17 @@ class EkcoM3:
         return HeatingStatus.IDLE
 
     @property
-    def cwu_heating_status(self) -> HeatingStatus:
-        """CWU heating status from mode, water heater, CWU active, and power."""
+    def dhw_heating_status(self) -> HeatingStatus:
+        """DHW heating status from mode, water heater, DHW active, and power."""
         heater_mode = self.heater_mode
         water_enabled = self.is_water_heater_enabled
-        cwu_active = self.is_cwu_heating_active
+        dhw_active = self.is_dhw_heating_active
         power_val = self.power
 
         if heater_mode == HeaterMode.SUMMER:
             return (
                 HeatingStatus.RUNNING
-                if cwu_active == HeatingCircuitActive.ACTIVE
+                if dhw_active == HeatingCircuitActive.ACTIVE
                 else HeatingStatus.IDLE
             )
 
@@ -410,7 +410,7 @@ class EkcoM3:
         if water_enabled != WaterHeaterEnabled.ENABLED:
             return HeatingStatus.DISABLED
 
-        if cwu_active != HeatingCircuitActive.ACTIVE:
+        if dhw_active != HeatingCircuitActive.ACTIVE:
             return HeatingStatus.IDLE
 
         if power_val is not None and power_val > 0:
@@ -440,11 +440,11 @@ class EkcoM3:
         await self._backend.write_register("0b32", hex_val)
         self._registers["0b32"] = hex_val
 
-    async def set_cwu_mode(self, value: int) -> None:
-        """Set CWU mode (0b30). 0=economy, 1=anti-freeze, 2=comfort."""
+    async def set_dhw_mode(self, value: int) -> None:
+        """Set DHW mode (0b30). 0=economy, 1=anti-freeze, 2=comfort."""
         hex_val = encode_raw_int(value, None)
         if hex_val is None:
-            raise ValueError("Failed to encode cwu_mode")
+            raise ValueError("Failed to encode dhw_mode")
 
         await self._backend.write_register("0b30", hex_val)
         self._registers["0b30"] = hex_val
@@ -508,12 +508,12 @@ class EkcoM3:
         """Set room temperature comfort- (0b69), °C."""
         await self._set_scaled_x10("0b69", value)
 
-    async def set_cwu_temperature_economy(self, value: float) -> None:
-        """Set CWU economy temperature (0b66), °C."""
+    async def set_dhw_temperature_economy(self, value: float) -> None:
+        """Set DHW economy temperature (0b66), °C."""
         await self._set_scaled_x10("0b66", value)
 
-    async def set_cwu_temperature_comfort(self, value: float) -> None:
-        """Set CWU comfort temperature (0b67), °C."""
+    async def set_dhw_temperature_comfort(self, value: float) -> None:
+        """Set DHW comfort temperature (0b67), °C."""
         await self._set_scaled_x10("0b67", value)
 
     async def set_party_vacation_end_minute(self, value: int) -> None:
@@ -561,19 +561,19 @@ class EkcoM3:
         await self.set_heater_mode(HeaterMode.MANUAL)
         await self.set_manual_temperature(temperature)
 
-    async def set_water_mode(self, mode: CwuMode) -> None:
-        """Set CWU water mode (which temperature source is active)."""
-        if not isinstance(mode, CwuMode):
-            raise TypeError(f"mode must be CwuMode, got {type(mode).__name__}")
-        await self.set_cwu_mode(mode.value)
+    async def set_water_mode(self, mode: DhwMode) -> None:
+        """Set DHW water mode (which temperature source is active)."""
+        if not isinstance(mode, DhwMode):
+            raise TypeError(f"mode must be DhwMode, got {type(mode).__name__}")
+        await self.set_dhw_mode(mode.value)
 
     async def set_water_comfort_temperature(self, temperature: float) -> None:
-        """Set CWU comfort temperature (0b67), °C."""
-        await self.set_cwu_temperature_comfort(temperature)
+        """Set DHW comfort temperature (0b67), °C."""
+        await self.set_dhw_temperature_comfort(temperature)
 
     async def set_water_economy_temperature(self, temperature: float) -> None:
-        """Set CWU economy temperature (0b66), °C."""
-        await self.set_cwu_temperature_economy(temperature)
+        """Set DHW economy temperature (0b66), °C."""
+        await self.set_dhw_temperature_economy(temperature)
 
     # --- Convenience methods for HA integration ---
 

--- a/lib/src/kospel_cmi/registers/enums.py
+++ b/lib/src/kospel_cmi/registers/enums.py
@@ -34,7 +34,7 @@ class ValvePosition(Enum):
 class HeatingStatus(Enum):
     """Heating circuit status matching manufacturer UI icons."""
 
-    RUNNING = "running"  # Red: circuit active, power > 0 (or cwu in summer)
+    RUNNING = "running"  # Red: circuit active, power > 0 (or dhw in summer)
     IDLE = "idle"  # Green: circuit active, not heating
     DISABLED = "disabled"  # Grey: circuit inactive
 
@@ -46,16 +46,16 @@ class HeatingCircuitActive(Enum):
     INACTIVE = "inactive"
 
 
-class CwuMode(IntEnum):
-    """CWU (domestic hot water) mode — which temperature source is active.
+class DhwMode(IntEnum):
+    """DHW (domestic hot water) mode — which temperature source is active.
 
     Stored in register 0b30. Values: 0=economy (0b66), 1=anti-freeze,
     2=comfort (0b67).
     """
 
-    ECONOMY = 0  # Uses cwu_temperature_economy (0b66)
+    ECONOMY = 0  # Uses dhw_temperature_economy (0b66)
     ANTI_FREEZE = 1  # Anti-freeze protection
-    COMFORT = 2  # Uses cwu_temperature_comfort (0b67)
+    COMFORT = 2  # Uses dhw_temperature_comfort (0b67)
 
 
 

--- a/lib/tests/unit/controller/test_device.py
+++ b/lib/tests/unit/controller/test_device.py
@@ -9,7 +9,7 @@ from kospel_cmi.exceptions import (
     RegisterMissingError,
 )
 from kospel_cmi.registers.enums import (
-    CwuMode,
+    DhwMode,
     HeaterMode,
     HeatingStatus,
 )
@@ -251,29 +251,29 @@ class TestEkcoM3:
     async def test_set_water_mode_writes_mode_only(
         self,
     ) -> None:
-        """set_water_mode sets cwu_mode only (0b30)."""
+        """set_water_mode sets dhw_mode only (0b30)."""
         backend = MockRegisterBackend({"0b30": "0100"})
         controller = EkcoM3(backend=backend)
         controller.from_registers(await backend.read_registers("0b00", 256))
-        await controller.set_water_mode(CwuMode.COMFORT)
+        await controller.set_water_mode(DhwMode.COMFORT)
         written_registers = {r for r, _ in backend.writes}
         assert written_registers == {"0b30"}
         assert backend.registers["0b30"] == "0200"  # 2 in little-endian
 
     @pytest.mark.asyncio
     async def test_set_water_mode_raises_on_invalid_type(self) -> None:
-        """set_water_mode raises TypeError when mode is not CwuMode."""
+        """set_water_mode raises TypeError when mode is not DhwMode."""
         backend = MockRegisterBackend({"0b30": "0100"})
         controller = EkcoM3(backend=backend)
         controller.from_registers(await backend.read_registers("0b00", 256))
-        with pytest.raises(TypeError, match="mode must be CwuMode"):
+        with pytest.raises(TypeError, match="mode must be DhwMode"):
             await controller.set_water_mode(2)  # type: ignore[arg-type]
 
     @pytest.mark.asyncio
     async def test_set_water_comfort_temperature_writes_temp_only(
         self,
     ) -> None:
-        """set_water_comfort_temperature sets cwu_temperature_comfort only (0b67)."""
+        """set_water_comfort_temperature sets dhw_temperature_comfort only (0b67)."""
         backend = MockRegisterBackend({"0b30": "0200", "0b67": "6801"})
         controller = EkcoM3(backend=backend)
         controller.from_registers(await backend.read_registers("0b00", 256))
@@ -286,7 +286,7 @@ class TestEkcoM3:
     async def test_set_water_economy_temperature_writes_temp_only(
         self,
     ) -> None:
-        """set_water_economy_temperature sets cwu_temperature_economy only (0b66)."""
+        """set_water_economy_temperature sets dhw_temperature_economy only (0b66)."""
         backend = MockRegisterBackend({"0b30": "0000", "0b66": "6801"})
         controller = EkcoM3(backend=backend)
         controller.from_registers(await backend.read_registers("0b00", 256))
@@ -348,82 +348,82 @@ class TestEkcoM3:
             await controller.set_boiler_max_power_index(-1)
 
     @pytest.mark.asyncio
-    async def test_co_heating_status_summer_disabled(self) -> None:
-        """In summer mode, CO is always DISABLED."""
+    async def test_ch_heating_status_summer_disabled(self) -> None:
+        """In summer mode, CH is always DISABLED."""
         backend = MockRegisterBackend(
             {"0b55": "0800", "0b51": "0000", "0b46": "0000"}
         )
         controller = EkcoM3(backend=backend)
         controller.from_registers(await backend.read_registers("0b00", 256))
-        assert controller.co_heating_status == HeatingStatus.DISABLED
+        assert controller.ch_heating_status == HeatingStatus.DISABLED
 
     @pytest.mark.asyncio
-    async def test_co_heating_status_winter_running(self) -> None:
-        """In winter mode with co=1 and power>0, CO is RUNNING."""
+    async def test_ch_heating_status_winter_running(self) -> None:
+        """In winter mode with co=1 and power>0, CH is RUNNING."""
         backend = MockRegisterBackend(
             {"0b55": "2000", "0b51": "8000", "0b46": "5000"}
         )
         controller = EkcoM3(backend=backend)
         controller.from_registers(await backend.read_registers("0b00", 256))
-        assert controller.co_heating_status == HeatingStatus.RUNNING
+        assert controller.ch_heating_status == HeatingStatus.RUNNING
 
     @pytest.mark.asyncio
-    async def test_co_heating_status_winter_idle(self) -> None:
-        """In winter mode with co=1 and power=0, CO is IDLE."""
+    async def test_ch_heating_status_winter_idle(self) -> None:
+        """In winter mode with co=1 and power=0, CH is IDLE."""
         backend = MockRegisterBackend(
             {"0b55": "2000", "0b51": "8000", "0b46": "0000"}
         )
         controller = EkcoM3(backend=backend)
         controller.from_registers(await backend.read_registers("0b00", 256))
-        assert controller.co_heating_status == HeatingStatus.IDLE
+        assert controller.ch_heating_status == HeatingStatus.IDLE
 
     @pytest.mark.asyncio
-    async def test_cwu_heating_status_summer_running(self) -> None:
-        """In summer mode with cwu=1, CWU is RUNNING (no power check)."""
+    async def test_dhw_heating_status_summer_running(self) -> None:
+        """In summer mode with cwu=1, DHW is RUNNING (no power check)."""
         backend = MockRegisterBackend(
             {"0b55": "0800", "0b51": "0001", "0b46": "0000"}
         )
         controller = EkcoM3(backend=backend)
         controller.from_registers(await backend.read_registers("0b00", 256))
-        assert controller.cwu_heating_status == HeatingStatus.RUNNING
+        assert controller.dhw_heating_status == HeatingStatus.RUNNING
 
     @pytest.mark.asyncio
-    async def test_cwu_heating_status_summer_idle(self) -> None:
-        """In summer mode with cwu=0, CWU is IDLE."""
+    async def test_dhw_heating_status_summer_idle(self) -> None:
+        """In summer mode with cwu=0, DHW is IDLE."""
         backend = MockRegisterBackend(
             {"0b55": "0800", "0b51": "0000", "0b46": "0000"}
         )
         controller = EkcoM3(backend=backend)
         controller.from_registers(await backend.read_registers("0b00", 256))
-        assert controller.cwu_heating_status == HeatingStatus.IDLE
+        assert controller.dhw_heating_status == HeatingStatus.IDLE
 
     @pytest.mark.asyncio
-    async def test_cwu_heating_status_winter_running(self) -> None:
-        """In winter with water enabled, cwu=1, power>0, CWU is RUNNING."""
+    async def test_dhw_heating_status_winter_running(self) -> None:
+        """In winter with water enabled, cwu=1, power>0, DHW is RUNNING."""
         backend = MockRegisterBackend(
             {"0b55": "3000", "0b51": "0001", "0b46": "5000"}
         )
         controller = EkcoM3(backend=backend)
         controller.from_registers(await backend.read_registers("0b00", 256))
-        assert controller.cwu_heating_status == HeatingStatus.RUNNING
+        assert controller.dhw_heating_status == HeatingStatus.RUNNING
 
     @pytest.mark.asyncio
-    async def test_cwu_heating_status_winter_disabled_when_water_off(self) -> None:
-        """In winter with water disabled, CWU is DISABLED."""
+    async def test_dhw_heating_status_winter_disabled_when_water_off(self) -> None:
+        """In winter with water disabled, DHW is DISABLED."""
         backend = MockRegisterBackend(
             {"0b55": "2000", "0b51": "0001", "0b46": "5000"}
         )
         controller = EkcoM3(backend=backend)
         controller.from_registers(await backend.read_registers("0b00", 256))
-        assert controller.cwu_heating_status == HeatingStatus.DISABLED
+        assert controller.dhw_heating_status == HeatingStatus.DISABLED
 
     @pytest.mark.asyncio
-    async def test_co_cwu_heating_status_other_modes_disabled(self) -> None:
-        """In OFF/PARTY/VACATION/MANUAL, both CO and CWU are DISABLED."""
+    async def test_ch_dhw_heating_status_other_modes_disabled(self) -> None:
+        """In OFF/PARTY/VACATION/MANUAL, both CH and DHW are DISABLED."""
         backend = MockRegisterBackend(
             {"0b55": "0000", "0b51": "8001", "0b46": "5000"}
         )
         controller = EkcoM3(backend=backend)
         controller.from_registers(await backend.read_registers("0b00", 256))
-        assert controller.co_heating_status == HeatingStatus.DISABLED
-        assert controller.cwu_heating_status == HeatingStatus.DISABLED
+        assert controller.ch_heating_status == HeatingStatus.DISABLED
+        assert controller.dhw_heating_status == HeatingStatus.DISABLED

--- a/tests/integration/test_water_heater_registers.py
+++ b/tests/integration/test_water_heater_registers.py
@@ -42,10 +42,10 @@ class TestWaterHeaterRegisters:
     async def test_cwu_temperatures_decoded(
         self, heater_controller_with_registers: EkcoM3
     ) -> None:
-        """cwu_temperature_economy and cwu_temperature_comfort are decoded."""
+        """dhw_temperature_economy and dhw_temperature_comfort are decoded."""
         controller = heater_controller_with_registers
-        assert controller.cwu_temperature_economy == 40.0
-        assert controller.cwu_temperature_comfort == 45.0
+        assert controller.dhw_temperature_economy == 40.0
+        assert controller.dhw_temperature_comfort == 45.0
 
     @pytest.mark.asyncio
     async def test_supply_setpoint_decoded(

--- a/tests/test_climate_entity.py
+++ b/tests/test_climate_entity.py
@@ -357,7 +357,7 @@ class TestClimateHvacAction:
     ) -> None:
         """hvac_action returns HEATING when CH status is RUNNING."""
         mock_controller = MagicMock()
-        mock_controller.co_heating_status = HeatingStatus.RUNNING
+        mock_controller.ch_heating_status = HeatingStatus.RUNNING
         mock_coordinator.data = mock_controller
 
         assert climate_entity.hvac_action == HVACAction.HEATING
@@ -367,7 +367,7 @@ class TestClimateHvacAction:
     ) -> None:
         """hvac_action returns OFF when CH status is IDLE."""
         mock_controller = MagicMock()
-        mock_controller.co_heating_status = HeatingStatus.IDLE
+        mock_controller.ch_heating_status = HeatingStatus.IDLE
         mock_coordinator.data = mock_controller
 
         assert climate_entity.hvac_action == HVACAction.OFF
@@ -377,7 +377,7 @@ class TestClimateHvacAction:
     ) -> None:
         """hvac_action returns OFF when CH status is DISABLED."""
         mock_controller = MagicMock()
-        mock_controller.co_heating_status = HeatingStatus.DISABLED
+        mock_controller.ch_heating_status = HeatingStatus.DISABLED
         mock_coordinator.data = mock_controller
 
         assert climate_entity.hvac_action == HVACAction.OFF

--- a/tests/test_number_entity.py
+++ b/tests/test_number_entity.py
@@ -176,7 +176,7 @@ class TestKospelPresetNumberEntity:
             mock_coordinator,
             mock_entry,
             "dhw_temperature_economy",
-            "cwu_temperature_economy",
+            "dhw_temperature_economy",
             "set_water_economy_temperature",
             DHW_PRESET_TEMP_MIN,
             DHW_PRESET_TEMP_MAX,
@@ -236,8 +236,8 @@ class TestKospelPresetNumberEntity:
             ("room_temperature_comfort", "set_room_temperature_comfort", "room_temperature_comfort"),
             ("room_temperature_comfort_plus", "set_room_temperature_comfort_plus", "room_temperature_comfort_plus"),
             ("room_temperature_comfort_minus", "set_room_temperature_comfort_minus", "room_temperature_comfort_minus"),
-            ("dhw_temperature_economy", "set_water_economy_temperature", "cwu_temperature_economy"),
-            ("dhw_temperature_comfort", "set_water_comfort_temperature", "cwu_temperature_comfort"),
+            ("dhw_temperature_economy", "set_water_economy_temperature", "dhw_temperature_economy"),
+            ("dhw_temperature_comfort", "set_water_comfort_temperature", "dhw_temperature_comfort"),
         ],
     )
     async def test_each_preset_uses_matching_setter(
@@ -255,8 +255,8 @@ class TestKospelPresetNumberEntity:
             ("room_temperature_comfort", "set_room_temperature_comfort", "room_temperature_comfort"),
             ("room_temperature_comfort_plus", "set_room_temperature_comfort_plus", "room_temperature_comfort_plus"),
             ("room_temperature_comfort_minus", "set_room_temperature_comfort_minus", "room_temperature_comfort_minus"),
-            ("dhw_temperature_economy", "set_water_economy_temperature", "cwu_temperature_economy"),
-            ("dhw_temperature_comfort", "set_water_comfort_temperature", "cwu_temperature_comfort"),
+            ("dhw_temperature_economy", "set_water_economy_temperature", "dhw_temperature_economy"),
+            ("dhw_temperature_comfort", "set_water_comfort_temperature", "dhw_temperature_comfort"),
         ]:
             setattr(mock_controller, _setter, AsyncMock(return_value=True))
         mock_coordinator.data = mock_controller

--- a/tests/test_sensor_entity.py
+++ b/tests/test_sensor_entity.py
@@ -220,8 +220,8 @@ class TestKospelHeatingModeSensorNativeValue:
     ) -> None:
         """native_value is 'ch' when CH is running."""
         mock_controller = MagicMock()
-        mock_controller.co_heating_status = "running"
-        mock_controller.cwu_heating_status = "idle"
+        mock_controller.ch_heating_status = "running"
+        mock_controller.dhw_heating_status = "idle"
         mock_coordinator.data = mock_controller
 
         entity = KospelHeatingModeSensor(mock_coordinator, mock_entry)
@@ -232,8 +232,8 @@ class TestKospelHeatingModeSensorNativeValue:
     ) -> None:
         """native_value is 'dhw' when DHW is running."""
         mock_controller = MagicMock()
-        mock_controller.co_heating_status = "idle"
-        mock_controller.cwu_heating_status = "running"
+        mock_controller.ch_heating_status = "idle"
+        mock_controller.dhw_heating_status = "running"
         mock_coordinator.data = mock_controller
 
         entity = KospelHeatingModeSensor(mock_coordinator, mock_entry)
@@ -244,8 +244,8 @@ class TestKospelHeatingModeSensorNativeValue:
     ) -> None:
         """native_value is 'idle' when both are idle."""
         mock_controller = MagicMock()
-        mock_controller.co_heating_status = "idle"
-        mock_controller.cwu_heating_status = "idle"
+        mock_controller.ch_heating_status = "idle"
+        mock_controller.dhw_heating_status = "idle"
         mock_coordinator.data = mock_controller
 
         entity = KospelHeatingModeSensor(mock_coordinator, mock_entry)
@@ -256,8 +256,8 @@ class TestKospelHeatingModeSensorNativeValue:
     ) -> None:
         """native_value is 'idle' when CH is idle and DHW disabled."""
         mock_controller = MagicMock()
-        mock_controller.co_heating_status = "idle"
-        mock_controller.cwu_heating_status = "disabled"
+        mock_controller.ch_heating_status = "idle"
+        mock_controller.dhw_heating_status = "disabled"
         mock_coordinator.data = mock_controller
 
         entity = KospelHeatingModeSensor(mock_coordinator, mock_entry)
@@ -268,8 +268,8 @@ class TestKospelHeatingModeSensorNativeValue:
     ) -> None:
         """native_value is 'off' when both are disabled."""
         mock_controller = MagicMock()
-        mock_controller.co_heating_status = "disabled"
-        mock_controller.cwu_heating_status = "disabled"
+        mock_controller.ch_heating_status = "disabled"
+        mock_controller.dhw_heating_status = "disabled"
         mock_coordinator.data = mock_controller
 
         entity = KospelHeatingModeSensor(mock_coordinator, mock_entry)
@@ -284,8 +284,8 @@ class TestKospelHeatingModeSensorNativeValue:
         mock_ch_status.value = "RUNNING"
         mock_dwh_status = MagicMock()
         mock_dwh_status.value = "IDLE"
-        mock_controller.co_heating_status = mock_ch_status
-        mock_controller.cwu_heating_status = mock_dwh_status
+        mock_controller.ch_heating_status = mock_ch_status
+        mock_controller.dhw_heating_status = mock_dwh_status
         mock_coordinator.data = mock_controller
 
         entity = KospelHeatingModeSensor(mock_coordinator, mock_entry)
@@ -296,7 +296,7 @@ class TestKospelHeatingModeSensorNativeValue:
     ) -> None:
         """native_value is None when CH status is missing."""
         mock_controller = MagicMock(spec=[])
-        mock_controller.cwu_heating_status = "idle"
+        mock_controller.dhw_heating_status = "idle"
         mock_coordinator.data = mock_controller
 
         entity = KospelHeatingModeSensor(mock_coordinator, mock_entry)
@@ -307,7 +307,7 @@ class TestKospelHeatingModeSensorNativeValue:
     ) -> None:
         """native_value is None when DHW status is missing."""
         mock_controller = MagicMock(spec=[])
-        mock_controller.co_heating_status = "idle"
+        mock_controller.ch_heating_status = "idle"
         mock_coordinator.data = mock_controller
 
         entity = KospelHeatingModeSensor(mock_coordinator, mock_entry)

--- a/tests/test_water_heater_entity.py
+++ b/tests/test_water_heater_entity.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from kospel_cmi.registers.enums import CwuMode
+from kospel_cmi.registers.enums import DhwMode
 
 
 # Mock homeassistant before importing integration modules.
@@ -98,12 +98,12 @@ class TestWaterHeaterTargetTemperature:
     def test_target_temperature_returns_supply_setpoint(
         self, water_heater_entity, mock_coordinator
     ) -> None:
-        """target_temperature returns supply_setpoint regardless of cwu_mode."""
+        """target_temperature returns supply_setpoint regardless of dhw_mode."""
         mock_controller = MagicMock()
         mock_controller.supply_setpoint = 15.0
-        mock_controller.cwu_mode = CwuMode.ANTI_FREEZE
-        mock_controller.cwu_temperature_economy = 40.0
-        mock_controller.cwu_temperature_comfort = 45.0
+        mock_controller.dhw_mode = DhwMode.ANTI_FREEZE
+        mock_controller.dhw_temperature_economy = 40.0
+        mock_controller.dhw_temperature_comfort = 45.0
         mock_coordinator.data = mock_controller
 
         assert water_heater_entity.target_temperature == 15.0
@@ -114,26 +114,26 @@ class TestWaterHeaterTargetTemperature:
         """target_temperature returns None when supply_setpoint is unavailable."""
         mock_controller = MagicMock()
         mock_controller.supply_setpoint = None
-        mock_controller.cwu_mode = CwuMode.ECONOMY
-        mock_controller.cwu_temperature_economy = 40.0
-        mock_controller.cwu_temperature_comfort = 45.0
+        mock_controller.dhw_mode = DhwMode.ECONOMY
+        mock_controller.dhw_temperature_economy = 40.0
+        mock_controller.dhw_temperature_comfort = 45.0
         mock_coordinator.data = mock_controller
 
         assert water_heater_entity.target_temperature is None
 
 
 class TestWaterHeaterCurrentOperation:
-    """Tests for current_operation (from cwu_mode)."""
+    """Tests for current_operation (from dhw_mode)."""
 
-    def test_current_operation_eco_when_cwu_mode_economy(
+    def test_current_operation_eco_when_dhw_mode_economy(
         self, water_heater_entity, mock_coordinator
     ) -> None:
-        """current_operation returns eco when cwu_mode is economy."""
+        """current_operation returns eco when dhw_mode is economy."""
         from kospel_cmi.registers.enums import WaterHeaterEnabled
 
         mock_controller = MagicMock()
         mock_controller.is_water_heater_enabled = WaterHeaterEnabled.ENABLED
-        mock_controller.cwu_mode = CwuMode.ECONOMY
+        mock_controller.dhw_mode = DhwMode.ECONOMY
         mock_coordinator.data = mock_controller
 
         assert water_heater_entity.current_operation == STATE_ECO
@@ -146,20 +146,20 @@ class TestWaterHeaterCurrentOperation:
 
         mock_controller = MagicMock()
         mock_controller.is_water_heater_enabled = WaterHeaterEnabled.DISABLED
-        mock_controller.cwu_mode = CwuMode.ECONOMY
+        mock_controller.dhw_mode = DhwMode.ECONOMY
         mock_coordinator.data = mock_controller
 
         assert water_heater_entity.current_operation == STATE_OFF
 
-    def test_current_operation_performance_when_cwu_mode_comfort(
+    def test_current_operation_performance_when_dhw_mode_comfort(
         self, water_heater_entity, mock_coordinator
     ) -> None:
-        """current_operation returns performance when cwu_mode is comfort."""
+        """current_operation returns performance when dhw_mode is comfort."""
         from kospel_cmi.registers.enums import WaterHeaterEnabled
 
         mock_controller = MagicMock()
         mock_controller.is_water_heater_enabled = WaterHeaterEnabled.ENABLED
-        mock_controller.cwu_mode = CwuMode.COMFORT
+        mock_controller.dhw_mode = DhwMode.COMFORT
         mock_coordinator.data = mock_controller
 
         assert water_heater_entity.current_operation == STATE_PERFORMANCE


### PR DESCRIPTION
Refactor: rename CWU/DHW and CO/CH identifiers for consistency across the library and Home Assistant integration.

### What was changed
- Replaced all `CwuMode` with `DhwMode` and all `cwu_*` properties with `dhw_*` in the library and integration code.
- Updated async setters/getters (`set_water_mode`, `set_water_*`, etc.) to use `DhwMode`.
- Adjusted Home Assistant entities (`water_heater`, `number`, `climate`, `sensor`) to reference the new DHW identifiers.
- Updated documentation (README, controller README, registers README) and code comments to reflect the new naming.
- Modified all unit and integration tests to use the new identifiers.
- Fixed remaining references in README files and examples.
- Added missing `aiohttp` dependency via `uv add aiohttp`.
- **Fixed backward compatibility for Home Assistant entities** by adding `unique_id_suffix` support to `number.py`, ensuring that setting renames don't break existing `unique_id`s.
- Simplified `_PRESET_ENTITIES` in `number.py` by combining identical `translation_key` and `value_attr`.
- Migrated agent instructions from `CLAUDE.md` to `.agents/AGENTS.md` and added a new rule documenting the `unique_id` requirement to prevent future breaking changes.

All tests now pass. This rename improves consistency with the English‑based naming convention used throughout the project.

Refs #65

BEGIN_COMMIT_OVERRIDE
fix: rename cwu/co identifiers to dhw/ch across codebase
END_COMMIT_OVERRIDE