### PR TITLE
chore: fix release-please config to use separate changelog for lib

### DIFF
--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -12,21 +12,14 @@
 
 ### Bug Fixes
 
-* **ha:** remove aiohttp strict constraint to fix HA core conflict ([48565c7](https://github.com/JanKrl/ha-kospel-cmi/commit/48565c70501f4858fb96be5028b0376da41f998f))
-* **ha:** remove strict aiohttp requirement ([#80](https://github.com/JanKrl/ha-kospel-cmi/issues/80)) ([223f763](https://github.com/JanKrl/ha-kospel-cmi/commit/223f7637e1237ef7c2967672f1e22efe16580423))
 * relax library dependency versions for HA compatibility ([#90](https://github.com/JanKrl/ha-kospel-cmi/issues/90)) ([13cd1e6](https://github.com/JanKrl/ha-kospel-cmi/commit/13cd1e6a8e2c66f5bea86af1fc370f1f31f8ff16))
-* resolve enum error by publishing library and forcing upgrade ([#87](https://github.com/JanKrl/ha-kospel-cmi/issues/87)) ([8c79abf](https://github.com/JanKrl/ha-kospel-cmi/commit/8c79abf46962dccbfbc79252d9d615acd95a8cde))
-* standardize enum values and resolve translation mismatches ([#66](https://github.com/JanKrl/ha-kospel-cmi/issues/66)) ([f05e68b](https://github.com/JanKrl/ha-kospel-cmi/commit/f05e68b8176687f8174fe622bd87320c09eaccd7))
 
 ## [1.1.4](https://github.com/JanKrl/ha-kospel-cmi/compare/lib-v1.1.3...lib-v1.1.4) (2026-07-18)
 
 
 ### Bug Fixes
 
-* **ha:** remove aiohttp strict constraint to fix HA core conflict ([48565c7](https://github.com/JanKrl/ha-kospel-cmi/commit/48565c70501f4858fb96be5028b0376da41f998f))
-* **ha:** remove strict aiohttp requirement ([#80](https://github.com/JanKrl/ha-kospel-cmi/issues/80)) ([223f763](https://github.com/JanKrl/ha-kospel-cmi/commit/223f7637e1237ef7c2967672f1e22efe16580423))
 * resolve enum error by publishing library and forcing upgrade ([#87](https://github.com/JanKrl/ha-kospel-cmi/issues/87)) ([8c79abf](https://github.com/JanKrl/ha-kospel-cmi/commit/8c79abf46962dccbfbc79252d9d615acd95a8cde))
-* standardize enum values and resolve translation mismatches ([#66](https://github.com/JanKrl/ha-kospel-cmi/issues/66)) ([f05e68b](https://github.com/JanKrl/ha-kospel-cmi/commit/f05e68b8176687f8174fe622bd87320c09eaccd7))
 
 ## [1.1.3](https://github.com/JanKrl/ha-kospel-cmi/compare/lib-v1.1.2...lib-v1.1.3) (2026-07-18)
 
@@ -43,9 +36,3 @@
 
 * standardize enum values and resolve translation mismatches ([#66](https://github.com/JanKrl/ha-kospel-cmi/issues/66)) ([f05e68b](https://github.com/JanKrl/ha-kospel-cmi/commit/f05e68b8176687f8174fe622bd87320c09eaccd7))
 
-## [1.1.1](https://github.com/JanKrl/ha-kospel-cmi/compare/lib-v1.1.0...lib-v1.1.1) (2026-07-18)
-
-
-### Bug Fixes
-
-* standardize enum values and resolve translation mismatches ([#66](https://github.com/JanKrl/ha-kospel-cmi/issues/66)) ([f05e68b](https://github.com/JanKrl/ha-kospel-cmi/commit/f05e68b8176687f8174fe622bd87320c09eaccd7))

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,7 +23,7 @@
       "release-type": "python",
       "package-name": "kospel-cmi-lib",
       "component": "lib",
-      "changelog-path": "CHANGELOG.md",
+      "changelog-path": "lib/CHANGELOG.md",
       "bump-minor-pre-major": true,
       "include-component-in-tag": true,
       "skip-github-release": true


### PR DESCRIPTION
This PR fixes a configuration issue where release-please incorrectly used the root `CHANGELOG.md` for both the HA integration and the `lib` component. This caused release-please to mix up versions and duplicate old commits in new release PRs. This PR also cleans up the duplicated entries from `lib/CHANGELOG.md`.