### PR TITLE
ci: exclude lib and common files from root release package

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,6 +11,11 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "include-component-in-tag": false,
+      "exclude-paths": [
+        "lib/**",
+        "uv.lock",
+        ".github/**"
+      ],
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
This PR fixes an issue where commits modifying only library or common repository files (like uv.lock) were incorrectly triggering a release for the Home Assistant integration (the root package).

By excluding `lib/**`, `uv.lock`, and `.github/**` from the root package's release-please configuration, only changes specific to the HA integration will appear in the main changelog.