### PR TITLE
ci: use PAT for merge command to trigger workflows

### DIFF
--- a/.github/workflows/command-merge.yaml
+++ b/.github/workflows/command-merge.yaml
@@ -16,7 +16,7 @@ jobs:
       
       - name: Verify and Merge
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
           PR_NUMBER=${{ github.event.issue.number }}
           


### PR DESCRIPTION
Uses RELEASE_PLEASE_TOKEN in the /merge command workflow. By default, actions performed with GITHUB_TOKEN do not trigger other workflows (like release-please) to prevent recursive loops. Using a PAT ensures that PRs merged via the command properly trigger release-please.