### PR TITLE
ci: fix exclude-paths patterns

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,9 +12,9 @@
       "bump-patch-for-minor-pre-major": true,
       "include-component-in-tag": false,
       "exclude-paths": [
-        "lib/**",
+        "lib",
         "uv.lock",
-        ".github/**"
+        ".github"
       ],
       "extra-files": [
         {


### PR DESCRIPTION
Release Please uses prefix matching, not globs.