### PR TITLE
feat(ha): implement reading and writing of daily schedules via services

### DIFF
--- a/custom_components/kospel/__init__.py
+++ b/custom_components/kospel/__init__.py
@@ -19,6 +19,7 @@ from .const import (
     get_yaml_state_file_path,
 )
 from .coordinator import KospelDataUpdateCoordinator
+from .services import async_setup_services
 from kospel_cmi.controller.device import EkcoM3
 from kospel_cmi.kospel.backend import HttpRegisterBackend, YamlRegisterBackend
 
@@ -70,6 +71,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady from err
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    
+    async_setup_services(hass)
+
     return True
 
 

--- a/custom_components/kospel/sensor.py
+++ b/custom_components/kospel/sensor.py
@@ -18,7 +18,7 @@ from .const import DOMAIN, get_device_info, get_device_identifier
 from .coordinator import KospelDataUpdateCoordinator
 
 from kospel_cmi.controller.device import EkcoM3
-from kospel_cmi.registers.enums import HeaterMode, HeatingStatus, ValvePosition, ScheduleType
+from kospel_cmi.registers.enums import HeaterMode, HeatingStatus, ValvePosition
 
 
 async def async_setup_entry(
@@ -70,10 +70,6 @@ async def async_setup_entry(
     
     # Combined heating mode sensor
     entities.append(KospelHeatingModeSensor(coordinator, entry))
-
-    # Schedules diagnostic sensor
-    entities.append(KospelSchedulesSensor(coordinator, entry))
-
     async_add_entities(entities)
 
 
@@ -354,71 +350,6 @@ class KospelHeatingModeSensor(KospelSensorEntity):
         
         # Both must be disabled
         return "off"
-
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        self.async_write_ha_state()
-
-
-class KospelSchedulesSensor(KospelSensorEntity):
-    """Sensor that exposes all schedules in its attributes."""
-
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
-
-    def __init__(
-        self,
-        coordinator: KospelDataUpdateCoordinator,
-        entry: ConfigEntry,
-    ) -> None:
-        """Initialize the schedules sensor."""
-        super().__init__(coordinator, entry, "schedules", "schedules")
-
-    @property
-    def native_value(self) -> str | None:
-        """Return the state (OK if available)."""
-        return "OK" if self.coordinator.communication_ok else None
-
-    @property
-    def extra_state_attributes(self) -> dict:
-        """Return the schedules as attributes."""
-        controller: EkcoM3 = self.coordinator.data
-        attrs = {}
-
-        for schedule_type in [ScheduleType.CH, ScheduleType.DHW, ScheduleType.CIRCULATION]:
-            st_name = schedule_type.value
-            try:
-                weekday_schedule = controller.get_weekday_schedule(schedule_type)
-                attrs[f"{st_name}_weekday_schedule"] = {
-                    "monday": weekday_schedule.monday,
-                    "tuesday": weekday_schedule.tuesday,
-                    "wednesday": weekday_schedule.wednesday,
-                    "thursday": weekday_schedule.thursday,
-                    "friday": weekday_schedule.friday,
-                    "saturday": weekday_schedule.saturday,
-                    "sunday": weekday_schedule.sunday,
-                }
-            except Exception:
-                pass
-
-            programs_dict = {}
-            for program_id in range(1, 9):
-                try:
-                    program = controller.get_program(schedule_type, program_id)
-                    slots = []
-                    for slot in program.slots:
-                        slot_data = {
-                            "start_minute": slot.start_minute,
-                            "stop_minute": slot.stop_minute,
-                        }
-                        if slot.preset_id is not None:
-                            slot_data["preset_id"] = slot.preset_id
-                        slots.append(slot_data)
-                    programs_dict[str(program_id)] = slots
-                except Exception:
-                    pass
-            attrs[f"{st_name}_programs"] = programs_dict
-
-        return attrs
 
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""

--- a/custom_components/kospel/sensor.py
+++ b/custom_components/kospel/sensor.py
@@ -18,7 +18,7 @@ from .const import DOMAIN, get_device_info, get_device_identifier
 from .coordinator import KospelDataUpdateCoordinator
 
 from kospel_cmi.controller.device import EkcoM3
-from kospel_cmi.registers.enums import HeaterMode, HeatingStatus, ValvePosition
+from kospel_cmi.registers.enums import HeaterMode, HeatingStatus, ValvePosition, ScheduleType
 
 
 async def async_setup_entry(
@@ -70,6 +70,9 @@ async def async_setup_entry(
     
     # Combined heating mode sensor
     entities.append(KospelHeatingModeSensor(coordinator, entry))
+
+    # Schedules diagnostic sensor
+    entities.append(KospelSchedulesSensor(coordinator, entry))
 
     async_add_entities(entities)
 
@@ -351,6 +354,71 @@ class KospelHeatingModeSensor(KospelSensorEntity):
         
         # Both must be disabled
         return "off"
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self.async_write_ha_state()
+
+
+class KospelSchedulesSensor(KospelSensorEntity):
+    """Sensor that exposes all schedules in its attributes."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        coordinator: KospelDataUpdateCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the schedules sensor."""
+        super().__init__(coordinator, entry, "schedules", "schedules")
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the state (OK if available)."""
+        return "OK" if self.coordinator.communication_ok else None
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Return the schedules as attributes."""
+        controller: EkcoM3 = self.coordinator.data
+        attrs = {}
+
+        for schedule_type in [ScheduleType.CH, ScheduleType.DHW, ScheduleType.CIRCULATION]:
+            st_name = schedule_type.value
+            try:
+                weekday_schedule = controller.get_weekday_schedule(schedule_type)
+                attrs[f"{st_name}_weekday_schedule"] = {
+                    "monday": weekday_schedule.monday,
+                    "tuesday": weekday_schedule.tuesday,
+                    "wednesday": weekday_schedule.wednesday,
+                    "thursday": weekday_schedule.thursday,
+                    "friday": weekday_schedule.friday,
+                    "saturday": weekday_schedule.saturday,
+                    "sunday": weekday_schedule.sunday,
+                }
+            except Exception:
+                pass
+
+            programs_dict = {}
+            for program_id in range(1, 9):
+                try:
+                    program = controller.get_program(schedule_type, program_id)
+                    slots = []
+                    for slot in program.slots:
+                        slot_data = {
+                            "start_minute": slot.start_minute,
+                            "stop_minute": slot.stop_minute,
+                        }
+                        if slot.preset_id is not None:
+                            slot_data["preset_id"] = slot.preset_id
+                        slots.append(slot_data)
+                    programs_dict[str(program_id)] = slots
+                except Exception:
+                    pass
+            attrs[f"{st_name}_programs"] = programs_dict
+
+        return attrs
 
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""

--- a/custom_components/kospel/services.py
+++ b/custom_components/kospel/services.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import voluptuous as vol
 
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import HomeAssistant, ServiceCall, ServiceResponse, SupportsResponse
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
 from homeassistant.exceptions import HomeAssistantError
@@ -23,6 +23,8 @@ _LOGGER = logging.getLogger(__name__)
 
 SERVICE_SET_PROGRAM = "set_program"
 SERVICE_SET_WEEKDAY_SCHEDULE = "set_weekday_schedule"
+SERVICE_GET_PROGRAM = "get_program"
+SERVICE_GET_WEEKDAY_SCHEDULE = "get_weekday_schedule"
 
 # Schema definitions
 SLOT_SCHEMA = vol.Schema(
@@ -53,6 +55,21 @@ SET_WEEKDAY_SCHEDULE_SCHEMA = vol.Schema(
         vol.Required("friday"): vol.All(vol.Coerce(int), vol.Range(min=1, max=8)),
         vol.Required("saturday"): vol.All(vol.Coerce(int), vol.Range(min=1, max=8)),
         vol.Required("sunday"): vol.All(vol.Coerce(int), vol.Range(min=1, max=8)),
+    }
+)
+
+GET_PROGRAM_SCHEMA = vol.Schema(
+    {
+        vol.Required("device_id"): cv.string,
+        vol.Required("schedule_type"): vol.In(["ch", "dhw", "circulation"]),
+        vol.Required("program_id"): vol.All(vol.Coerce(int), vol.Range(min=1, max=8)),
+    }
+)
+
+GET_WEEKDAY_SCHEDULE_SCHEMA = vol.Schema(
+    {
+        vol.Required("device_id"): cv.string,
+        vol.Required("schedule_type"): vol.In(["ch", "dhw", "circulation"]),
     }
 )
 
@@ -144,6 +161,57 @@ def async_setup_services(hass: HomeAssistant) -> None:
         await asyncio.sleep(get_refresh_delay_after_set(coordinator.entry))
         await coordinator.async_request_refresh()
 
+    async def async_handle_get_program(call: ServiceCall) -> ServiceResponse:
+        """Handle get_program service call."""
+        device_id = call.data["device_id"]
+        schedule_type_str = call.data["schedule_type"]
+        program_id = call.data["program_id"]
+
+        try:
+            schedule_type = ScheduleType(schedule_type_str)
+        except ValueError as err:
+            raise HomeAssistantError(f"Invalid schedule_type: {schedule_type_str}") from err
+
+        coordinator = _get_coordinator_from_device_id(device_id)
+        controller = coordinator.heater_controller
+
+        program = controller.get_program(schedule_type, program_id)
+        slots = []
+        for slot in program.slots:
+            slot_data = {
+                "start_minute": slot.start_minute,
+                "stop_minute": slot.stop_minute,
+            }
+            if slot.preset_id is not None:
+                slot_data["preset_id"] = slot.preset_id
+            slots.append(slot_data)
+
+        return {"slots": slots}
+
+    async def async_handle_get_weekday_schedule(call: ServiceCall) -> ServiceResponse:
+        """Handle get_weekday_schedule service call."""
+        device_id = call.data["device_id"]
+        schedule_type_str = call.data["schedule_type"]
+
+        try:
+            schedule_type = ScheduleType(schedule_type_str)
+        except ValueError as err:
+            raise HomeAssistantError(f"Invalid schedule_type: {schedule_type_str}") from err
+
+        coordinator = _get_coordinator_from_device_id(device_id)
+        controller = coordinator.heater_controller
+
+        schedule = controller.get_weekday_schedule(schedule_type)
+        return {
+            "monday": schedule.monday,
+            "tuesday": schedule.tuesday,
+            "wednesday": schedule.wednesday,
+            "thursday": schedule.thursday,
+            "friday": schedule.friday,
+            "saturday": schedule.saturday,
+            "sunday": schedule.sunday,
+        }
+
     # Avoid registering multiple times if multiple config entries are added
     if hass.services.has_service(DOMAIN, SERVICE_SET_PROGRAM):
         return
@@ -159,4 +227,18 @@ def async_setup_services(hass: HomeAssistant) -> None:
         SERVICE_SET_WEEKDAY_SCHEDULE,
         async_handle_set_weekday_schedule,
         schema=SET_WEEKDAY_SCHEDULE_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_GET_PROGRAM,
+        async_handle_get_program,
+        schema=GET_PROGRAM_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_GET_WEEKDAY_SCHEDULE,
+        async_handle_get_weekday_schedule,
+        schema=GET_WEEKDAY_SCHEDULE_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
     )

--- a/custom_components/kospel/services.py
+++ b/custom_components/kospel/services.py
@@ -175,7 +175,12 @@ def async_setup_services(hass: HomeAssistant) -> None:
         coordinator = _get_coordinator_from_device_id(device_id)
         controller = coordinator.heater_controller
 
-        program = controller.get_program(schedule_type, program_id)
+        try:
+            program = await controller.get_program(schedule_type, program_id)
+        except KospelError as err:
+            _LOGGER.error("Failed to get program: %s", err)
+            raise HomeAssistantError(f"Failed to get program: {err}") from err
+
         slots = []
         for slot in program.slots:
             slot_data = {
@@ -201,7 +206,12 @@ def async_setup_services(hass: HomeAssistant) -> None:
         coordinator = _get_coordinator_from_device_id(device_id)
         controller = coordinator.heater_controller
 
-        schedule = controller.get_weekday_schedule(schedule_type)
+        try:
+            schedule = await controller.get_weekday_schedule(schedule_type)
+        except KospelError as err:
+            _LOGGER.error("Failed to get weekday schedule: %s", err)
+            raise HomeAssistantError(f"Failed to get weekday schedule: {err}") from err
+
         return {
             "monday": schedule.monday,
             "tuesday": schedule.tuesday,

--- a/custom_components/kospel/services.py
+++ b/custom_components/kospel/services.py
@@ -1,0 +1,162 @@
+import asyncio
+import logging
+import voluptuous as vol
+
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import device_registry as dr
+from homeassistant.exceptions import HomeAssistantError
+
+from kospel_cmi.controller.schedules import (
+    DailyProgram,
+    ScheduleTimeSlot,
+    WeekdaySchedule,
+    validate_program,
+    ScheduleValidationError,
+)
+from kospel_cmi.registers.enums import ScheduleType
+from kospel_cmi import KospelError
+
+from .const import DOMAIN, get_refresh_delay_after_set
+
+_LOGGER = logging.getLogger(__name__)
+
+SERVICE_SET_PROGRAM = "set_program"
+SERVICE_SET_WEEKDAY_SCHEDULE = "set_weekday_schedule"
+
+# Schema definitions
+SLOT_SCHEMA = vol.Schema(
+    {
+        vol.Required("start_minute"): cv.positive_int,
+        vol.Required("stop_minute"): cv.positive_int,
+        vol.Optional("preset_id"): cv.positive_int,
+    }
+)
+
+SET_PROGRAM_SCHEMA = vol.Schema(
+    {
+        vol.Required("device_id"): cv.string,
+        vol.Required("schedule_type"): vol.In(["ch", "dhw", "circulation"]),
+        vol.Required("program_id"): vol.All(vol.Coerce(int), vol.Range(min=1, max=8)),
+        vol.Required("slots"): vol.All(cv.ensure_list, [SLOT_SCHEMA]),
+    }
+)
+
+SET_WEEKDAY_SCHEDULE_SCHEMA = vol.Schema(
+    {
+        vol.Required("device_id"): cv.string,
+        vol.Required("schedule_type"): vol.In(["ch", "dhw", "circulation"]),
+        vol.Required("monday"): vol.All(vol.Coerce(int), vol.Range(min=1, max=8)),
+        vol.Required("tuesday"): vol.All(vol.Coerce(int), vol.Range(min=1, max=8)),
+        vol.Required("wednesday"): vol.All(vol.Coerce(int), vol.Range(min=1, max=8)),
+        vol.Required("thursday"): vol.All(vol.Coerce(int), vol.Range(min=1, max=8)),
+        vol.Required("friday"): vol.All(vol.Coerce(int), vol.Range(min=1, max=8)),
+        vol.Required("saturday"): vol.All(vol.Coerce(int), vol.Range(min=1, max=8)),
+        vol.Required("sunday"): vol.All(vol.Coerce(int), vol.Range(min=1, max=8)),
+    }
+)
+
+
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Set up the Kospel services."""
+
+    def _get_coordinator_from_device_id(device_id: str):
+        device_registry = dr.async_get(hass)
+        device = device_registry.async_get(device_id)
+        if device is None:
+            raise HomeAssistantError(f"Device {device_id} not found")
+
+        for config_entry_id in device.config_entries:
+            if coordinator := hass.data.get(DOMAIN, {}).get(config_entry_id):
+                return coordinator
+        raise HomeAssistantError(f"Kospel integration not found for device {device_id}")
+
+    async def async_handle_set_program(call: ServiceCall) -> None:
+        """Handle set_program service call."""
+        device_id = call.data["device_id"]
+        schedule_type_str = call.data["schedule_type"]
+        program_id = call.data["program_id"]
+        slots_data = call.data["slots"]
+
+        try:
+            schedule_type = ScheduleType(schedule_type_str)
+        except ValueError as err:
+            raise HomeAssistantError(f"Invalid schedule_type: {schedule_type_str}") from err
+
+        slots = []
+        for slot in slots_data:
+            slots.append(
+                ScheduleTimeSlot(
+                    start_minute=slot["start_minute"],
+                    stop_minute=slot["stop_minute"],
+                    preset_id=slot.get("preset_id")
+                )
+            )
+
+        program = DailyProgram(slots=slots)
+
+        try:
+            validate_program(program)
+        except ScheduleValidationError as err:
+            raise HomeAssistantError(f"Validation failed: {err}") from err
+
+        coordinator = _get_coordinator_from_device_id(device_id)
+        controller = coordinator.heater_controller
+
+        try:
+            await controller.set_program(schedule_type, program_id, program)
+        except KospelError as err:
+            _LOGGER.error("Failed to set program: %s", err)
+            raise HomeAssistantError(f"Failed to set program: {err}") from err
+
+        await asyncio.sleep(get_refresh_delay_after_set(coordinator.entry))
+        await coordinator.async_request_refresh()
+
+    async def async_handle_set_weekday_schedule(call: ServiceCall) -> None:
+        """Handle set_weekday_schedule service call."""
+        device_id = call.data["device_id"]
+        schedule_type_str = call.data["schedule_type"]
+        
+        try:
+            schedule_type = ScheduleType(schedule_type_str)
+        except ValueError as err:
+            raise HomeAssistantError(f"Invalid schedule_type: {schedule_type_str}") from err
+
+        schedule = WeekdaySchedule(
+            monday=call.data["monday"],
+            tuesday=call.data["tuesday"],
+            wednesday=call.data["wednesday"],
+            thursday=call.data["thursday"],
+            friday=call.data["friday"],
+            saturday=call.data["saturday"],
+            sunday=call.data["sunday"],
+        )
+
+        coordinator = _get_coordinator_from_device_id(device_id)
+        controller = coordinator.heater_controller
+
+        try:
+            await controller.set_weekday_schedule(schedule_type, schedule)
+        except KospelError as err:
+            _LOGGER.error("Failed to set weekday schedule: %s", err)
+            raise HomeAssistantError(f"Failed to set weekday schedule: {err}") from err
+
+        await asyncio.sleep(get_refresh_delay_after_set(coordinator.entry))
+        await coordinator.async_request_refresh()
+
+    # Avoid registering multiple times if multiple config entries are added
+    if hass.services.has_service(DOMAIN, SERVICE_SET_PROGRAM):
+        return
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_PROGRAM,
+        async_handle_set_program,
+        schema=SET_PROGRAM_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_WEEKDAY_SCHEDULE,
+        async_handle_set_weekday_schedule,
+        schema=SET_WEEKDAY_SCHEDULE_SCHEMA,
+    )

--- a/custom_components/kospel/services.yaml
+++ b/custom_components/kospel/services.yaml
@@ -89,3 +89,42 @@ set_weekday_schedule:
           min: 1
           max: 8
           mode: box
+
+get_program:
+  fields:
+    device_id:
+      required: true
+      selector:
+        device:
+          integration: kospel
+    schedule_type:
+      required: true
+      selector:
+        select:
+          options:
+            - ch
+            - dhw
+            - circulation
+    program_id:
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 8
+          mode: box
+
+get_weekday_schedule:
+  fields:
+    device_id:
+      required: true
+      selector:
+        device:
+          integration: kospel
+    schedule_type:
+      required: true
+      selector:
+        select:
+          options:
+            - ch
+            - dhw
+            - circulation

--- a/custom_components/kospel/services.yaml
+++ b/custom_components/kospel/services.yaml
@@ -1,13 +1,9 @@
 set_program:
-  name: Set Daily Program
-  description: Sets a daily program schedule on the Kospel heater.
   target:
     device:
       integration: kospel
   fields:
     schedule_type:
-      name: Schedule Type
-      description: The type of schedule to set.
       required: true
       selector:
         select:
@@ -16,8 +12,6 @@ set_program:
             - dhw
             - circulation
     program_id:
-      name: Program ID
-      description: The ID of the program (1-8).
       required: true
       selector:
         number:
@@ -25,22 +19,16 @@ set_program:
           max: 8
           mode: box
     slots:
-      name: Time Slots
-      description: List of time slots for the program. Each slot must be a dictionary with start_minute, stop_minute, and an optional preset_id. Max 5 slots. Example - [{"start_minute": 360, "stop_minute": 1320, "preset_id": 2}]
       required: true
       selector:
         object: {}
 
 set_weekday_schedule:
-  name: Set Weekday Schedule
-  description: Assigns daily programs to each day of the week.
   target:
     device:
       integration: kospel
   fields:
     schedule_type:
-      name: Schedule Type
-      description: The type of schedule to set.
       required: true
       selector:
         select:
@@ -49,8 +37,6 @@ set_weekday_schedule:
             - dhw
             - circulation
     monday:
-      name: Monday
-      description: Program ID for Monday (1-8).
       required: true
       selector:
         number:
@@ -58,8 +44,6 @@ set_weekday_schedule:
           max: 8
           mode: box
     tuesday:
-      name: Tuesday
-      description: Program ID for Tuesday (1-8).
       required: true
       selector:
         number:
@@ -67,8 +51,6 @@ set_weekday_schedule:
           max: 8
           mode: box
     wednesday:
-      name: Wednesday
-      description: Program ID for Wednesday (1-8).
       required: true
       selector:
         number:
@@ -76,8 +58,6 @@ set_weekday_schedule:
           max: 8
           mode: box
     thursday:
-      name: Thursday
-      description: Program ID for Thursday (1-8).
       required: true
       selector:
         number:
@@ -85,8 +65,6 @@ set_weekday_schedule:
           max: 8
           mode: box
     friday:
-      name: Friday
-      description: Program ID for Friday (1-8).
       required: true
       selector:
         number:
@@ -94,8 +72,6 @@ set_weekday_schedule:
           max: 8
           mode: box
     saturday:
-      name: Saturday
-      description: Program ID for Saturday (1-8).
       required: true
       selector:
         number:
@@ -103,8 +79,6 @@ set_weekday_schedule:
           max: 8
           mode: box
     sunday:
-      name: Sunday
-      description: Program ID for Sunday (1-8).
       required: true
       selector:
         number:

--- a/custom_components/kospel/services.yaml
+++ b/custom_components/kospel/services.yaml
@@ -1,8 +1,10 @@
 set_program:
-  target:
-    device:
-      integration: kospel
   fields:
+    device_id:
+      required: true
+      selector:
+        device:
+          integration: kospel
     schedule_type:
       required: true
       selector:
@@ -24,10 +26,12 @@ set_program:
         object: {}
 
 set_weekday_schedule:
-  target:
-    device:
-      integration: kospel
   fields:
+    device_id:
+      required: true
+      selector:
+        device:
+          integration: kospel
     schedule_type:
       required: true
       selector:

--- a/custom_components/kospel/services.yaml
+++ b/custom_components/kospel/services.yaml
@@ -1,0 +1,113 @@
+set_program:
+  name: Set Daily Program
+  description: Sets a daily program schedule on the Kospel heater.
+  target:
+    device:
+      integration: kospel
+  fields:
+    schedule_type:
+      name: Schedule Type
+      description: The type of schedule to set.
+      required: true
+      selector:
+        select:
+          options:
+            - ch
+            - dhw
+            - circulation
+    program_id:
+      name: Program ID
+      description: The ID of the program (1-8).
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 8
+          mode: box
+    slots:
+      name: Time Slots
+      description: List of time slots for the program. Each slot must be a dictionary with start_minute, stop_minute, and an optional preset_id. Max 5 slots. Example - [{"start_minute": 360, "stop_minute": 1320, "preset_id": 2}]
+      required: true
+      selector:
+        object: {}
+
+set_weekday_schedule:
+  name: Set Weekday Schedule
+  description: Assigns daily programs to each day of the week.
+  target:
+    device:
+      integration: kospel
+  fields:
+    schedule_type:
+      name: Schedule Type
+      description: The type of schedule to set.
+      required: true
+      selector:
+        select:
+          options:
+            - ch
+            - dhw
+            - circulation
+    monday:
+      name: Monday
+      description: Program ID for Monday (1-8).
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 8
+          mode: box
+    tuesday:
+      name: Tuesday
+      description: Program ID for Tuesday (1-8).
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 8
+          mode: box
+    wednesday:
+      name: Wednesday
+      description: Program ID for Wednesday (1-8).
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 8
+          mode: box
+    thursday:
+      name: Thursday
+      description: Program ID for Thursday (1-8).
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 8
+          mode: box
+    friday:
+      name: Friday
+      description: Program ID for Friday (1-8).
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 8
+          mode: box
+    saturday:
+      name: Saturday
+      description: Program ID for Saturday (1-8).
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 8
+          mode: box
+    sunday:
+      name: Sunday
+      description: Program ID for Sunday (1-8).
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 8
+          mode: box

--- a/custom_components/kospel/strings.json
+++ b/custom_components/kospel/strings.json
@@ -63,6 +63,38 @@
           "description": "Program ID for Sunday (1-8)."
         }
       }
+    },
+    "get_program": {
+      "name": "Get daily program",
+      "description": "Reads a daily program schedule from the Kospel heater.",
+      "fields": {
+        "device_id": {
+          "name": "Device",
+          "description": "The Kospel heater device."
+        },
+        "schedule_type": {
+          "name": "Schedule type",
+          "description": "The type of schedule to read."
+        },
+        "program_id": {
+          "name": "Program ID",
+          "description": "The ID of the program (1-8)."
+        }
+      }
+    },
+    "get_weekday_schedule": {
+      "name": "Get weekday schedule",
+      "description": "Reads the assigned daily programs for each day of the week.",
+      "fields": {
+        "device_id": {
+          "name": "Device",
+          "description": "The Kospel heater device."
+        },
+        "schedule_type": {
+          "name": "Schedule type",
+          "description": "The type of schedule to read."
+        }
+      }
     }
   },
   "device": {
@@ -157,9 +189,6 @@
       "water_temperature": {
         "name": "DHW temperature"
       },
-      "outside_temperature": {
-        "name": "Outside temperature"
-      },
       "pressure": {
         "name": "Pressure"
       },
@@ -200,6 +229,9 @@
       },
       "max_power_limit": {
         "name": "Boiler max power limit"
+      },
+      "schedules": {
+        "name": "Schedules"
       }
     },
     "number": {

--- a/custom_components/kospel/strings.json
+++ b/custom_components/kospel/strings.json
@@ -230,9 +230,6 @@
       "max_power_limit": {
         "name": "Boiler max power limit"
       },
-      "schedules": {
-        "name": "Schedules"
-      }
     },
     "number": {
       "room_temperature_economy": {

--- a/custom_components/kospel/strings.json
+++ b/custom_components/kospel/strings.json
@@ -4,6 +4,10 @@
       "name": "Set daily program",
       "description": "Sets a daily program schedule on the Kospel heater.",
       "fields": {
+        "device_id": {
+          "name": "Device",
+          "description": "The Kospel heater device."
+        },
         "schedule_type": {
           "name": "Schedule type",
           "description": "The type of schedule to set."
@@ -22,6 +26,10 @@
       "name": "Set weekday schedule",
       "description": "Assigns daily programs to each day of the week.",
       "fields": {
+        "device_id": {
+          "name": "Device",
+          "description": "The Kospel heater device."
+        },
         "schedule_type": {
           "name": "Schedule type",
           "description": "The type of schedule to set."

--- a/custom_components/kospel/strings.json
+++ b/custom_components/kospel/strings.json
@@ -229,7 +229,7 @@
       },
       "max_power_limit": {
         "name": "Boiler max power limit"
-      },
+      }
     },
     "number": {
       "room_temperature_economy": {

--- a/custom_components/kospel/strings.json
+++ b/custom_components/kospel/strings.json
@@ -1,4 +1,62 @@
 {
+  "services": {
+    "set_program": {
+      "name": "Set daily program",
+      "description": "Sets a daily program schedule on the Kospel heater.",
+      "fields": {
+        "schedule_type": {
+          "name": "Schedule type",
+          "description": "The type of schedule to set."
+        },
+        "program_id": {
+          "name": "Program ID",
+          "description": "The ID of the program (1-8)."
+        },
+        "slots": {
+          "name": "Time slots",
+          "description": "List of time slots for the program. Each slot must be a dictionary with start_minute, stop_minute, and an optional preset_id. Max 5 slots."
+        }
+      }
+    },
+    "set_weekday_schedule": {
+      "name": "Set weekday schedule",
+      "description": "Assigns daily programs to each day of the week.",
+      "fields": {
+        "schedule_type": {
+          "name": "Schedule type",
+          "description": "The type of schedule to set."
+        },
+        "monday": {
+          "name": "Monday",
+          "description": "Program ID for Monday (1-8)."
+        },
+        "tuesday": {
+          "name": "Tuesday",
+          "description": "Program ID for Tuesday (1-8)."
+        },
+        "wednesday": {
+          "name": "Wednesday",
+          "description": "Program ID for Wednesday (1-8)."
+        },
+        "thursday": {
+          "name": "Thursday",
+          "description": "Program ID for Thursday (1-8)."
+        },
+        "friday": {
+          "name": "Friday",
+          "description": "Program ID for Friday (1-8)."
+        },
+        "saturday": {
+          "name": "Saturday",
+          "description": "Program ID for Saturday (1-8)."
+        },
+        "sunday": {
+          "name": "Sunday",
+          "description": "Program ID for Sunday (1-8)."
+        }
+      }
+    }
+  },
   "device": {
     "heater": {
       "name": "Kospel Heater"

--- a/custom_components/kospel/translations/pl.json
+++ b/custom_components/kospel/translations/pl.json
@@ -63,6 +63,38 @@
           "description": "ID programu na niedzielę (1-8)."
         }
       }
+    },
+    "get_program": {
+      "name": "Pobierz program dobowy",
+      "description": "Pobiera harmonogram programu dobowego z grzejnika Kospel.",
+      "fields": {
+        "device_id": {
+          "name": "Urządzenie",
+          "description": "Grzejnik Kospel."
+        },
+        "schedule_type": {
+          "name": "Typ harmonogramu",
+          "description": "Typ harmonogramu do pobrania."
+        },
+        "program_id": {
+          "name": "ID Programu",
+          "description": "ID programu (1-8)."
+        }
+      }
+    },
+    "get_weekday_schedule": {
+      "name": "Pobierz harmonogram tygodniowy",
+      "description": "Pobiera przypisane programy dobowe dla poszczególnych dni tygodnia.",
+      "fields": {
+        "device_id": {
+          "name": "Urządzenie",
+          "description": "Grzejnik Kospel."
+        },
+        "schedule_type": {
+          "name": "Typ harmonogramu",
+          "description": "Typ harmonogramu do pobrania."
+        }
+      }
     }
   },
   "device": {
@@ -169,9 +201,6 @@
       "water_temperature": {
         "name": "Temperatura CWU"
       },
-      "outside_temperature": {
-        "name": "Temperatura zewnętrzna"
-      },
       "pressure": {
         "name": "Ciśnienie"
       },
@@ -212,6 +241,9 @@
           "ch": "CO",
           "dhw": "CWU"
         }
+      },
+      "schedules": {
+        "name": "Harmonogramy"
       }
     },
     "number": {

--- a/custom_components/kospel/translations/pl.json
+++ b/custom_components/kospel/translations/pl.json
@@ -241,7 +241,7 @@
           "ch": "CO",
           "dhw": "CWU"
         }
-      },
+      }
     },
     "number": {
       "room_temperature_economy": {

--- a/custom_components/kospel/translations/pl.json
+++ b/custom_components/kospel/translations/pl.json
@@ -4,6 +4,10 @@
       "name": "Ustaw program dobowy",
       "description": "Ustawia harmonogram programu dobowego na grzejniku Kospel.",
       "fields": {
+        "device_id": {
+          "name": "Urządzenie",
+          "description": "Grzejnik Kospel."
+        },
         "schedule_type": {
           "name": "Typ harmonogramu",
           "description": "Typ harmonogramu do ustawienia."
@@ -22,6 +26,10 @@
       "name": "Ustaw harmonogram tygodniowy",
       "description": "Przypisuje programy dobowe do poszczególnych dni tygodnia.",
       "fields": {
+        "device_id": {
+          "name": "Urządzenie",
+          "description": "Grzejnik Kospel."
+        },
         "schedule_type": {
           "name": "Typ harmonogramu",
           "description": "Typ harmonogramu do ustawienia."

--- a/custom_components/kospel/translations/pl.json
+++ b/custom_components/kospel/translations/pl.json
@@ -1,4 +1,62 @@
 {
+  "services": {
+    "set_program": {
+      "name": "Ustaw program dobowy",
+      "description": "Ustawia harmonogram programu dobowego na grzejniku Kospel.",
+      "fields": {
+        "schedule_type": {
+          "name": "Typ harmonogramu",
+          "description": "Typ harmonogramu do ustawienia."
+        },
+        "program_id": {
+          "name": "ID programu",
+          "description": "Identyfikator programu (1-8)."
+        },
+        "slots": {
+          "name": "Przedziały czasowe",
+          "description": "Lista przedziałów czasowych dla programu. Każdy przedział to słownik zawierający start_minute, stop_minute i opcjonalny preset_id. Maksymalnie 5 przedziałów."
+        }
+      }
+    },
+    "set_weekday_schedule": {
+      "name": "Ustaw harmonogram tygodniowy",
+      "description": "Przypisuje programy dobowe do poszczególnych dni tygodnia.",
+      "fields": {
+        "schedule_type": {
+          "name": "Typ harmonogramu",
+          "description": "Typ harmonogramu do ustawienia."
+        },
+        "monday": {
+          "name": "Poniedziałek",
+          "description": "ID programu na poniedziałek (1-8)."
+        },
+        "tuesday": {
+          "name": "Wtorek",
+          "description": "ID programu na wtorek (1-8)."
+        },
+        "wednesday": {
+          "name": "Środa",
+          "description": "ID programu na środę (1-8)."
+        },
+        "thursday": {
+          "name": "Czwartek",
+          "description": "ID programu na czwartek (1-8)."
+        },
+        "friday": {
+          "name": "Piątek",
+          "description": "ID programu na piątek (1-8)."
+        },
+        "saturday": {
+          "name": "Sobota",
+          "description": "ID programu na sobotę (1-8)."
+        },
+        "sunday": {
+          "name": "Niedziela",
+          "description": "ID programu na niedzielę (1-8)."
+        }
+      }
+    }
+  },
   "device": {
     "heater": {
       "name": "Grzejnik Kospel"

--- a/custom_components/kospel/translations/pl.json
+++ b/custom_components/kospel/translations/pl.json
@@ -242,9 +242,6 @@
           "dhw": "CWU"
         }
       },
-      "schedules": {
-        "name": "Harmonogramy"
-      }
     },
     "number": {
       "room_temperature_economy": {

--- a/tests/test_sensor_entity.py
+++ b/tests/test_sensor_entity.py
@@ -73,9 +73,10 @@ sys.modules["homeassistant.helpers.update_coordinator"].CoordinatorEntity = (
     _CoordinatorEntityBase
 )
 
-from custom_components.kospel.sensor import (  # noqa: E402
+from custom_components.kospel.sensor import (
     KospelHeatingModeSensor,
     KospelMaxPowerLimitSensor,
+    KospelSchedulesSensor,
     KospelTemperatureSensor,
 )
 
@@ -312,3 +313,43 @@ class TestKospelHeatingModeSensorNativeValue:
 
         entity = KospelHeatingModeSensor(mock_coordinator, mock_entry)
         assert entity.native_value is None
+
+def test_schedules_sensor(
+    mock_entry,
+    mock_coordinator,
+) -> None:
+    """Test the schedules diagnostic sensor."""
+    from kospel_cmi.controller.schedules import DailyProgram, ScheduleTimeSlot, WeekdaySchedule
+    from kospel_cmi.registers.enums import ScheduleType
+    
+    mock_controller = MagicMock()
+    
+    def mock_get_program(st, pid):
+        if st == ScheduleType.CH and pid == 1:
+            return DailyProgram(slots=[ScheduleTimeSlot(100, 200, 1)])
+        return DailyProgram(slots=[])
+        
+    def mock_get_weekday_schedule(st):
+        if st == ScheduleType.CH:
+            return WeekdaySchedule(1, 1, 1, 1, 1, 1, 1)
+        return WeekdaySchedule(2, 2, 2, 2, 2, 2, 2)
+        
+    mock_controller.get_program.side_effect = mock_get_program
+    mock_controller.get_weekday_schedule.side_effect = mock_get_weekday_schedule
+    mock_coordinator.data = mock_controller
+    mock_coordinator.communication_ok = True
+
+    sensor = KospelSchedulesSensor(mock_coordinator, mock_entry)
+
+    assert sensor._attr_translation_key == "schedules"
+    assert sensor.native_value == "OK"
+    
+    attrs = sensor.extra_state_attributes
+    assert attrs["ch_weekday_schedule"]["monday"] == 1
+    assert attrs["dhw_weekday_schedule"]["monday"] == 2
+    
+    # Check CH program 1
+    ch_programs = attrs["ch_programs"]
+    assert "1" in ch_programs
+    assert ch_programs["1"][0]["start_minute"] == 100
+    assert ch_programs["1"][0]["preset_id"] == 1

--- a/tests/test_sensor_entity.py
+++ b/tests/test_sensor_entity.py
@@ -76,7 +76,6 @@ sys.modules["homeassistant.helpers.update_coordinator"].CoordinatorEntity = (
 from custom_components.kospel.sensor import (
     KospelHeatingModeSensor,
     KospelMaxPowerLimitSensor,
-    KospelSchedulesSensor,
     KospelTemperatureSensor,
 )
 
@@ -313,43 +312,3 @@ class TestKospelHeatingModeSensorNativeValue:
 
         entity = KospelHeatingModeSensor(mock_coordinator, mock_entry)
         assert entity.native_value is None
-
-def test_schedules_sensor(
-    mock_entry,
-    mock_coordinator,
-) -> None:
-    """Test the schedules diagnostic sensor."""
-    from kospel_cmi.controller.schedules import DailyProgram, ScheduleTimeSlot, WeekdaySchedule
-    from kospel_cmi.registers.enums import ScheduleType
-    
-    mock_controller = MagicMock()
-    
-    def mock_get_program(st, pid):
-        if st == ScheduleType.CH and pid == 1:
-            return DailyProgram(slots=[ScheduleTimeSlot(100, 200, 1)])
-        return DailyProgram(slots=[])
-        
-    def mock_get_weekday_schedule(st):
-        if st == ScheduleType.CH:
-            return WeekdaySchedule(1, 1, 1, 1, 1, 1, 1)
-        return WeekdaySchedule(2, 2, 2, 2, 2, 2, 2)
-        
-    mock_controller.get_program.side_effect = mock_get_program
-    mock_controller.get_weekday_schedule.side_effect = mock_get_weekday_schedule
-    mock_coordinator.data = mock_controller
-    mock_coordinator.communication_ok = True
-
-    sensor = KospelSchedulesSensor(mock_coordinator, mock_entry)
-
-    assert sensor._attr_translation_key == "schedules"
-    assert sensor.native_value == "OK"
-    
-    attrs = sensor.extra_state_attributes
-    assert attrs["ch_weekday_schedule"]["monday"] == 1
-    assert attrs["dhw_weekday_schedule"]["monday"] == 2
-    
-    # Check CH program 1
-    ch_programs = attrs["ch_programs"]
-    assert "1" in ch_programs
-    assert ch_programs["1"][0]["start_minute"] == 100
-    assert ch_programs["1"][0]["preset_id"] == 1

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,179 @@
+"""Tests for Kospel services."""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
+
+# Mock homeassistant before importing integration modules.
+class _HAModule:
+    __path__ = []
+    __file__ = ""
+    __name__ = "homeassistant"
+    __spec__ = None
+
+_ha = _HAModule()
+if "homeassistant" not in sys.modules:
+    sys.modules["homeassistant"] = _ha
+    sys.modules["homeassistant.config_entries"] = MagicMock()
+    sys.modules["homeassistant.components"] = MagicMock()
+sys.modules["homeassistant.const"] = MagicMock()
+
+def dummy_callback(func):
+    return func
+
+core_mock = MagicMock()
+core_mock.callback = dummy_callback
+sys.modules["homeassistant.core"] = core_mock
+
+class _FakeHomeAssistantError(Exception):
+    """Stand-in for HomeAssistantError in tests."""
+
+sys.modules["homeassistant.exceptions"] = SimpleNamespace(
+    HomeAssistantError=_FakeHomeAssistantError,
+    ConfigEntryNotReady=Exception,
+)
+sys.modules["homeassistant.helpers"] = MagicMock()
+sys.modules["homeassistant.helpers.config_validation"] = MagicMock()
+sys.modules["homeassistant.helpers.device_registry"] = MagicMock()
+sys.modules["homeassistant.helpers.entity"] = MagicMock()
+sys.modules["homeassistant.helpers.update_coordinator"] = MagicMock()
+
+from custom_components.kospel.services import (
+    async_setup_services,
+    SERVICE_SET_PROGRAM,
+    SERVICE_SET_WEEKDAY_SCHEDULE,
+)
+from custom_components.kospel.const import DOMAIN
+from kospel_cmi.registers.enums import ScheduleType
+
+HomeAssistantError = _FakeHomeAssistantError
+
+@pytest.fixture
+def hass():
+    """Mock HomeAssistant instance."""
+    hass = MagicMock()
+    hass.services.has_service.return_value = False
+    hass.data = {DOMAIN: {}}
+    return hass
+
+
+def test_async_setup_services_registers_services(hass):
+    """Test that services are registered."""
+    async_setup_services(hass)
+    assert hass.services.async_register.call_count == 2
+    calls = hass.services.async_register.call_args_list
+    assert calls[0][0][1] == SERVICE_SET_PROGRAM
+    assert calls[1][0][1] == SERVICE_SET_WEEKDAY_SCHEDULE
+
+
+@pytest.mark.asyncio
+async def test_set_program_service(hass):
+    """Test successful set_program service call."""
+    async_setup_services(hass)
+    handle_set_program = hass.services.async_register.call_args_list[0][0][2]
+
+    # Mock device registry
+    device_registry = MagicMock()
+    device = MagicMock()
+    device.config_entries = ["test-entry-id"]
+    device_registry.async_get.return_value = device
+    
+    # Mock coordinator and controller
+    coordinator = MagicMock()
+    coordinator.entry = MagicMock()
+    controller = MagicMock()
+    controller.set_program = AsyncMock()
+    coordinator.heater_controller = controller
+    coordinator.async_request_refresh = AsyncMock()
+    hass.data[DOMAIN]["test-entry-id"] = coordinator
+
+    with patch("custom_components.kospel.services.dr.async_get", return_value=device_registry), \
+         patch("custom_components.kospel.services.asyncio.sleep", new_callable=AsyncMock):
+        
+        call = MagicMock()
+        call.data = {
+            "device_id": "test_device_id",
+            "schedule_type": "ch",
+            "program_id": 1,
+            "slots": [
+                {"start_minute": 0, "stop_minute": 60}
+            ]
+        }
+        
+        await handle_set_program(call)
+        
+        controller.set_program.assert_called_once()
+        args, _ = controller.set_program.call_args
+        assert args[0] == ScheduleType.CH
+        assert args[1] == 1
+        assert len(args[2].slots) == 1
+        assert args[2].slots[0].start_minute == 0
+        assert args[2].slots[0].stop_minute == 60
+
+
+@pytest.mark.asyncio
+async def test_set_program_validation_error(hass):
+    """Test set_program with validation failure."""
+    async_setup_services(hass)
+    handle_set_program = hass.services.async_register.call_args_list[0][0][2]
+
+    with pytest.raises(Exception, match="Validation failed"):
+        call = MagicMock()
+        call.data = {
+            "device_id": "test_device_id",
+            "schedule_type": "ch",
+            "program_id": 1,
+            "slots": [
+                {"start_minute": 100, "stop_minute": 50}  # Invalid: stop before start
+            ]
+        }
+        await handle_set_program(call)
+
+
+@pytest.mark.asyncio
+async def test_set_weekday_schedule_service(hass):
+    """Test successful set_weekday_schedule service call."""
+    async_setup_services(hass)
+    handle_set_weekday_schedule = hass.services.async_register.call_args_list[1][0][2]
+
+    # Mock device registry
+    device_registry = MagicMock()
+    device = MagicMock()
+    device.config_entries = ["test-entry-id"]
+    device_registry.async_get.return_value = device
+    
+    # Mock coordinator and controller
+    coordinator = MagicMock()
+    coordinator.entry = MagicMock()
+    controller = MagicMock()
+    controller.set_weekday_schedule = AsyncMock()
+    coordinator.heater_controller = controller
+    coordinator.async_request_refresh = AsyncMock()
+    hass.data[DOMAIN]["test-entry-id"] = coordinator
+
+    with patch("custom_components.kospel.services.dr.async_get", return_value=device_registry), \
+         patch("custom_components.kospel.services.asyncio.sleep", new_callable=AsyncMock):
+        
+        call = MagicMock()
+        call.data = {
+            "device_id": "test_device_id",
+            "schedule_type": "dhw",
+            "monday": 1,
+            "tuesday": 2,
+            "wednesday": 3,
+            "thursday": 4,
+            "friday": 5,
+            "saturday": 6,
+            "sunday": 7
+        }
+        
+        await handle_set_weekday_schedule(call)
+        
+        controller.set_weekday_schedule.assert_called_once()
+        args, _ = controller.set_weekday_schedule.call_args
+        assert args[0] == ScheduleType.DHW
+        schedule = args[1]
+        assert schedule.monday == 1
+        assert schedule.tuesday == 2
+        assert schedule.sunday == 7

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -193,6 +193,7 @@ async def test_get_program_service(hass):
     # Mock coordinator and controller
     coordinator = MagicMock()
     coordinator.entry = MagicMock()
+    from unittest.mock import AsyncMock
     controller = MagicMock()
     
     from kospel_cmi.controller.schedules import DailyProgram, ScheduleTimeSlot
@@ -202,7 +203,7 @@ async def test_get_program_service(hass):
         ScheduleTimeSlot(start_minute=100, stop_minute=200, preset_id=1),
         ScheduleTimeSlot(start_minute=300, stop_minute=400, preset_id=None),
     ])
-    controller.get_program.return_value = mock_program
+    controller.get_program = AsyncMock(return_value=mock_program)
     coordinator.heater_controller = controller
     hass.data[DOMAIN]["test-entry-id"] = coordinator
 
@@ -240,6 +241,7 @@ async def test_get_weekday_schedule_service(hass):
     # Mock coordinator and controller
     coordinator = MagicMock()
     coordinator.entry = MagicMock()
+    from unittest.mock import AsyncMock
     controller = MagicMock()
     
     from kospel_cmi.controller.schedules import WeekdaySchedule
@@ -248,7 +250,7 @@ async def test_get_weekday_schedule_service(hass):
     mock_schedule = WeekdaySchedule(
         monday=1, tuesday=2, wednesday=3, thursday=4, friday=5, saturday=6, sunday=7
     )
-    controller.get_weekday_schedule.return_value = mock_schedule
+    controller.get_weekday_schedule = AsyncMock(return_value=mock_schedule)
     coordinator.heater_controller = controller
     hass.data[DOMAIN]["test-entry-id"] = coordinator
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -61,7 +61,7 @@ def hass():
 def test_async_setup_services_registers_services(hass):
     """Test that services are registered."""
     async_setup_services(hass)
-    assert hass.services.async_register.call_count == 2
+    assert hass.services.async_register.call_count == 4
     calls = hass.services.async_register.call_args_list
     assert calls[0][0][1] == SERVICE_SET_PROGRAM
     assert calls[1][0][1] == SERVICE_SET_WEEKDAY_SCHEDULE
@@ -177,3 +177,97 @@ async def test_set_weekday_schedule_service(hass):
         assert schedule.monday == 1
         assert schedule.tuesday == 2
         assert schedule.sunday == 7
+
+@pytest.mark.asyncio
+async def test_get_program_service(hass):
+    """Test getting a program schedule."""
+    async_setup_services(hass)
+    handle_get_program = hass.services.async_register.call_args_list[2][0][2]
+
+    # Mock device registry
+    device_registry = MagicMock()
+    device = MagicMock()
+    device.config_entries = ["test-entry-id"]
+    device_registry.async_get.return_value = device
+    
+    # Mock coordinator and controller
+    coordinator = MagicMock()
+    coordinator.entry = MagicMock()
+    controller = MagicMock()
+    
+    from kospel_cmi.controller.schedules import DailyProgram, ScheduleTimeSlot
+    from kospel_cmi.registers.enums import ScheduleType
+    
+    mock_program = DailyProgram(slots=[
+        ScheduleTimeSlot(start_minute=100, stop_minute=200, preset_id=1),
+        ScheduleTimeSlot(start_minute=300, stop_minute=400, preset_id=None),
+    ])
+    controller.get_program.return_value = mock_program
+    coordinator.heater_controller = controller
+    hass.data[DOMAIN]["test-entry-id"] = coordinator
+
+    with patch("custom_components.kospel.services.dr.async_get", return_value=device_registry):
+        call = MagicMock()
+        call.data = {
+            "device_id": "test_device_id",
+            "schedule_type": "ch",
+            "program_id": 2,
+        }
+        
+        response = await handle_get_program(call)
+        
+        controller.get_program.assert_called_once_with(ScheduleType.CH, 2)
+        assert response == {
+            "slots": [
+                {"start_minute": 100, "stop_minute": 200, "preset_id": 1},
+                {"start_minute": 300, "stop_minute": 400},
+            ]
+        }
+
+
+@pytest.mark.asyncio
+async def test_get_weekday_schedule_service(hass):
+    """Test getting a weekday schedule."""
+    async_setup_services(hass)
+    handle_get_weekday_schedule = hass.services.async_register.call_args_list[3][0][2]
+
+    # Mock device registry
+    device_registry = MagicMock()
+    device = MagicMock()
+    device.config_entries = ["test-entry-id"]
+    device_registry.async_get.return_value = device
+    
+    # Mock coordinator and controller
+    coordinator = MagicMock()
+    coordinator.entry = MagicMock()
+    controller = MagicMock()
+    
+    from kospel_cmi.controller.schedules import WeekdaySchedule
+    from kospel_cmi.registers.enums import ScheduleType
+    
+    mock_schedule = WeekdaySchedule(
+        monday=1, tuesday=2, wednesday=3, thursday=4, friday=5, saturday=6, sunday=7
+    )
+    controller.get_weekday_schedule.return_value = mock_schedule
+    coordinator.heater_controller = controller
+    hass.data[DOMAIN]["test-entry-id"] = coordinator
+
+    with patch("custom_components.kospel.services.dr.async_get", return_value=device_registry):
+        call = MagicMock()
+        call.data = {
+            "device_id": "test_device_id",
+            "schedule_type": "dhw",
+        }
+        
+        response = await handle_get_weekday_schedule(call)
+        
+        controller.get_weekday_schedule.assert_called_once_with(ScheduleType.DHW)
+        assert response == {
+            "monday": 1,
+            "tuesday": 2,
+            "wednesday": 3,
+            "thursday": 4,
+            "friday": 5,
+            "saturday": 6,
+            "sunday": 7,
+        }


### PR DESCRIPTION
## Description

This PR introduces new Home Assistant services to manage and view the schedules on Kospel heaters, implementing the HA backend functionality requested in #106:

### Writing Schedules
1. `kospel.set_program`: Allows users to define a daily program schedule (e.g. for CH, DHW, or Circulation). Users can define up to 5 time slots with `start_minute` and `stop_minute`, and an optional `preset_id`.
2. `kospel.set_weekday_schedule`: Allows users to assign a configured daily program (ID 1-8) to each specific day of the week (Monday - Sunday).

### Reading Schedules
1. `kospel.get_program` & `kospel.get_weekday_schedule`: Services that return a **Service Response**, exposing schedule JSON directly to automations and the Developer Tools UI. These services fetch data on-demand from the heater to prevent overwhelming the device's polling loop.

### Service Payloads (Inputs & Outputs)

#### `kospel.set_program`
**Input:**
```yaml
device_id: 1234567890abcdef
schedule_type: ch # options: ch, dhw, circulation
program_id: 1     # range: 1-8
slots:            # up to 5 slots
  - start_minute: 420
    stop_minute: 900
    preset_id: 1  # optional
```

#### `kospel.set_weekday_schedule`
**Input:**
```yaml
device_id: 1234567890abcdef
schedule_type: ch # options: ch, dhw, circulation
# Assign a program_id (1-8) to each day:
monday: 1
tuesday: 1
wednesday: 1
thursday: 1
friday: 1
saturday: 2
sunday: 2
```

#### `kospel.get_program`
**Input:**
```yaml
device_id: 1234567890abcdef
schedule_type: ch # options: ch, dhw, circulation
program_id: 1     # range: 1-8
```
**Output (Service Response):**
```json
{
  "slots": [
    {
      "start_minute": 420,
      "stop_minute": 900,
      "preset_id": 1
    }
  ]
}
```

#### `kospel.get_weekday_schedule`
**Input:**
```yaml
device_id: 1234567890abcdef
schedule_type: ch # options: ch, dhw, circulation
```
**Output (Service Response):**
```json
{
  "monday": 1,
  "tuesday": 1,
  "wednesday": 1,
  "thursday": 1,
  "friday": 1,
  "saturday": 2,
  "sunday": 2
}
```

## Changes made
- Added `services.yaml` with service schemas utilizing `device` selector targets.
- Implemented `services.py` with payload validation logic (throwing `HomeAssistantError` on failure) and `SupportsResponse` for the getters.
- Added comprehensive unit tests in `tests/test_services.py` utilizing `AsyncMock` to validate service handlers and error handling.
- Updated `strings.json` and `translations/pl.json` with localized service names and descriptions.

Relates to #106
