### PR TITLE
chore: update manifest requirements for kospel-cmi-lib 2.0.0

### DIFF
--- a/custom_components/kospel/manifest.json
+++ b/custom_components/kospel/manifest.json
@@ -14,7 +14,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/JanKrl/ha-kospel-cmi/issues",
   "requirements": [
-    "kospel-cmi-lib==1.1.6"
+    "kospel-cmi-lib==2.0.0"
   ],
   "version": "1.3.4"
 }


### PR DESCRIPTION
This fixes the CI issue on the release-please PR by updating the manifest requirements to match the new library version 2.0.0. Since `release-please` force-pushes updates to its branch, we need to merge this into `master` first.