### PR TITLE
fix(ha): remove duplicate outside_temperature sensor definition

### DIFF
--- a/custom_components/kospel/sensor.py
+++ b/custom_components/kospel/sensor.py
@@ -37,7 +37,6 @@ async def async_setup_entry(
         ("room_temperature", "room_temperature"),
         ("outside_temperature", "outside_temperature"),
         ("water_temperature", "water_current_temperature"),
-        ("outside_temperature", "outside_temperature"),
     ]
 
     for unique_id_suffix, attr_name in temperature_sensors:


### PR DESCRIPTION
This PR fixes a duplicate unique ID error reported in Home Assistant logs:
`Platform kospel does not generate unique IDs. ID mi01_00006047_65_outside_temperature already exists - ignoring sensor.home_piec_elektryczny_temperatura_zewnetrzna`

## Changes:
- Removed duplicate `("outside_temperature", "outside_temperature")` entry from `temperature_sensors` array in `custom_components/kospel/sensor.py`.

Relates to #135